### PR TITLE
fix: 🐛 cookie max expire date for Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "husky": {
     "hooks": {
-      "commit-msg": "if [[ `git rev-parse --abbrev-ref HEAD` =~ ^(master|next)$ ]] ; then commitlint -E HUSKY_GIT_PARAMS ; fi"
+      "commit-msg": "bash -c \"if [[ `git rev-parse --abbrev-ref HEAD` =~ ^(master|next)$ ]] ; then commitlint -E HUSKY_GIT_PARAMS ; fi\""
     }
   }
 }

--- a/packages/core/src/storage/CookieStorage.js
+++ b/packages/core/src/storage/CookieStorage.js
@@ -11,7 +11,7 @@ import Window from '../window/Window';
  * @const
  * @type {Date}
  */
-const MAX_EXPIRE_DATE = new Date('Sat Sep 13 275760 00:00:00 GMT+0000 (UTC)');
+const MAX_EXPIRE_DATE = new Date('Fri, 31 Dec 9999 23:59:59 UTC');
 
 /**
  * Separator used to separate cookie declarations in the {@code Cookie} HTTP


### PR DESCRIPTION
 Edge not support max date value so I revert to previous safe value