### PR TITLE
fix: 🐛 getCurrentRouteInfo returns not-found instead exception

### DIFF
--- a/packages/core/src/router/AbstractRouter.js
+++ b/packages/core/src/router/AbstractRouter.js
@@ -197,10 +197,14 @@ export default class AbstractRouter extends Router {
     let route = this._getRouteByPath(path);
 
     if (!route) {
-      throw new GenericError(
-        `ima.core.router.AbstractRouter.getCurrentRouteInfo: The route ` +
-          `for path ${path} is not defined.`
-      );
+      route = this._routes.get(RouteNames.NOT_FOUND);
+
+      if (!route) {
+        throw new GenericError(
+          `ima.core.router.AbstractRouter.getCurrentRouteInfo: The route ` +
+            `for path ${path} is not defined.`
+        );
+      }
     }
 
     let params = route.extractParameters(path);


### PR DESCRIPTION
getCurrentRouteInfo returns not-found instead exception if not-found
route is set

BREAKING CHANGE: getCurrentRouteInfo returns not-found instead exception if not-found
route is set