### PR TITLE
fix: 🐛 allow to pass paramValue false or numeric zero,add slash

### DIFF
--- a/packages/core/src/router/Route.js
+++ b/packages/core/src/router/Route.js
@@ -391,7 +391,9 @@ export default class Route {
   _substituteRequiredParamInPath(path, paramName, paramValue) {
     return path.replace(
       new RegExp(`${PARAMS_START_PATTERN}:${paramName}(${PARAMS_END_PATTERN})`),
-      paramValue ? '$1' + encodeURIComponent(paramValue) + '$2' : ''
+      paramValue !== 'undefined'
+        ? '$1' + encodeURIComponent(paramValue) + '$2'
+        : '/'
     );
   }
 
@@ -407,7 +409,9 @@ export default class Route {
     const paramRegexp = `${PARAMS_START_PATTERN}:\\?${paramName}(${PARAMS_END_PATTERN})`;
     return path.replace(
       new RegExp(paramRegexp),
-      paramValue ? '$1' + encodeURIComponent(paramValue) + '$2' : '/'
+      paramValue !== undefined
+        ? '$1' + encodeURIComponent(paramValue) + '$2'
+        : '/'
     );
   }
 

--- a/packages/core/src/router/__tests__/RouteSpec.js
+++ b/packages/core/src/router/__tests__/RouteSpec.js
@@ -124,6 +124,21 @@ describe('ima.core.router.Route', function() {
           params: { action: 'view', route: 'users' },
           result: '/users/view'
         },
+        {
+          pathExpression: '/:?route/:?action/:?sort/:?page',
+          params: { action: 0, route: 'users', sort: false, page: 'page' },
+          result: '/users/0/false/page'
+        },
+        {
+          pathExpression: '/:?route/:?action/:?sort/:?page',
+          params: {
+            action: undefined,
+            route: 'users',
+            sort: false,
+            page: 'page'
+          },
+          result: '/users/false/page'
+        },
 
         {
           pathExpression: '/home/:userId/something/:somethingId/:?optional',


### PR DESCRIPTION
When value of param in route is numeric zero or boolean false the router
considers this as non-existing parameter. Condition has been changed to
detect undefined value only. Add slash when paramValue is undefined
fixes missing slash in url.