### PR TITLE
fix: query params parse

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1004,6 +1004,14 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@ima/helpers": {
+			"version": "17.4.0",
+			"resolved": "https://registry.npmjs.org/@ima/helpers/-/helpers-17.4.0.tgz",
+			"integrity": "sha512-qhmzrxxstPf7phZvrX0tsxJ0K7bMMs71cm8ejnj/AwaHlE4br/LdO1T2IQx35SaRPmkzG/mVI7VhYFTiaY9cNA==",
+			"requires": {
+				"clone": "^2.1.2"
+			}
+		},
 		"@jsbits/escape-regex-str": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@jsbits/escape-regex-str/-/escape-regex-str-1.0.3.tgz",
@@ -2509,6 +2517,11 @@
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^6.2.0"
 			}
+		},
+		"clone": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
 		},
 		"coa": {
 			"version": "2.0.2",

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1004,14 +1004,6 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@ima/helpers": {
-			"version": "17.4.0",
-			"resolved": "https://registry.npmjs.org/@ima/helpers/-/helpers-17.4.0.tgz",
-			"integrity": "sha512-qhmzrxxstPf7phZvrX0tsxJ0K7bMMs71cm8ejnj/AwaHlE4br/LdO1T2IQx35SaRPmkzG/mVI7VhYFTiaY9cNA==",
-			"requires": {
-				"clone": "^2.1.2"
-			}
-		},
 		"@jsbits/escape-regex-str": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@jsbits/escape-regex-str/-/escape-regex-str-1.0.3.tgz",
@@ -2517,11 +2509,6 @@
 				"strip-ansi": "^6.0.0",
 				"wrap-ansi": "^6.2.0"
 			}
-		},
-		"clone": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-			"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
 		},
 		"coa": {
 			"version": "2.0.2",

--- a/packages/core/src/router/Route.js
+++ b/packages/core/src/router/Route.js
@@ -811,8 +811,6 @@ export default class Route {
           }
         }
 
-        console.log(pair);
-
         query[this._decodeURIParameter(pair[0])] =
           pair.length > 1 ? this._decodeURIParameter(pair[1]) || '' : true;
       }

--- a/packages/core/src/router/Route.js
+++ b/packages/core/src/router/Route.js
@@ -755,7 +755,11 @@ export default class Route {
   _decodeURIParameter(parameterValue) {
     let decodedValue;
     if (parameterValue) {
-      decodedValue = decodeURIComponent(parameterValue);
+      try {
+        decodedValue = decodeURIComponent(parameterValue);
+      } catch (_) {
+        return '';
+      }
     }
     return decodedValue;
   }
@@ -807,8 +811,10 @@ export default class Route {
           }
         }
 
-        query[decodeURIComponent(pair[0])] =
-          pair.length > 1 ? decodeURIComponent(pair[1]) : true;
+        console.log(pair);
+
+        query[this._decodeURIParameter(pair[0])] =
+          pair.length > 1 ? this._decodeURIParameter(pair[1]) || '' : true;
       }
     }
 

--- a/packages/core/src/router/__tests__/RouteSpec.js
+++ b/packages/core/src/router/__tests__/RouteSpec.js
@@ -1653,9 +1653,7 @@ describe('ima.core.router.Route', function () {
     });
 
     it('should return empty string for query that cant be parsed', function () {
-      expect(
-        route._decodeURIParameter('p%F8%EDrodn%ED')
-      ).toEqual('');
+      expect(route._decodeURIParameter('p%F8%EDrodn%ED')).toEqual('');
     });
   });
 });

--- a/packages/core/src/router/__tests__/RouteSpec.js
+++ b/packages/core/src/router/__tests__/RouteSpec.js
@@ -1645,5 +1645,17 @@ describe('ima.core.router.Route', function () {
         stuff: ''
       });
     });
+
+    it('should parse query', function () {
+      expect(
+        route._decodeURIParameter(encodeURIComponent('á/b?č#d:ě%25'))
+      ).toEqual('á/b?č#d:ě%25');
+    });
+
+    it('should return empty string for query that cant be parsed', function () {
+      expect(
+        route._decodeURIParameter('p%F8%EDrodn%ED')
+      ).toEqual('');
+    });
   });
 });


### PR DESCRIPTION
query parameters that cant be parsed will be replaced with empty string