### PR TITLE
fix: 🐛 namespace.get now checks path type before split

### DIFF
--- a/packages/core/src/__tests__/NamespaceSpec.js
+++ b/packages/core/src/__tests__/NamespaceSpec.js
@@ -28,24 +28,38 @@ describe('Namespace', () => {
     expect(ns.a.b.c.ClassConstructor).toEqual(ClassConstructor);
   });
 
-  it('Should return undefined when creating namespace with wrong path format', () => {
-    expect(ns.namespace(false)).toEqual(undefined);
-    expect(ns.namespace(1)).toEqual(undefined);
-    expect(ns.namespace(null)).toEqual(undefined);
-    expect(ns.namespace(undefined)).toEqual(undefined);
+  it('Should throw error when creating namespace with wrong path format', () => {
+    expect(() => ns.namespace(false)).toThrow();
+    expect(() => ns.namespace(1)).toThrow();
+    expect(() => ns.namespace(null)).toThrow();
+    expect(() => ns.namespace(undefined)).toThrow();
   });
 
-  it('Should return undefined when getting wrong path format namespace value', () => {
-    expect(ns.get(false)).toEqual(undefined);
-    expect(ns.get(1)).toEqual(undefined);
-    expect(ns.get(null)).toEqual(undefined);
-    expect(ns.get(undefined)).toEqual(undefined);
+  it('Should throw error when getting wrong path format namespace value', () => {
+    expect(() => ns.get(false)).toThrow();
+    expect(() => ns.get(1)).toThrow();
+    expect(() => ns.get(null)).toThrow();
+    expect(() => ns.get(undefined)).toThrow();
   });
 
-  it('Should return undefined when setting wrong path format', () => {
-    expect(ns.set(false)).toEqual(undefined);
-    expect(ns.set(1)).toEqual(undefined);
-    expect(ns.set(null)).toEqual(undefined);
-    expect(ns.set(undefined)).toEqual(undefined);
+  it('Should throw error when setting wrong path format', () => {
+    expect(() => ns.set(false)).toThrow();
+    expect(() => ns.set(1)).toThrow();
+    expect(() => ns.set(null)).toThrow();
+    expect(() => ns.set(undefined)).toThrow();
+  });
+
+  it('Should return false when calling has wrong path format', () => {
+    expect(() => ns.has(false)).not.toThrow();
+    expect(ns.has(false)).toBeFalsy();
+
+    expect(() => ns.has(1)).not.toThrow();
+    expect(ns.has(1)).toBeFalsy();
+
+    expect(() => ns.has(null)).not.toThrow();
+    expect(ns.has(null)).toBeFalsy();
+
+    expect(() => ns.has(undefined)).not.toThrow();
+    expect(ns.has(undefined)).toBeFalsy();
   });
 });

--- a/packages/core/src/__tests__/NamespaceSpec.js
+++ b/packages/core/src/__tests__/NamespaceSpec.js
@@ -27,4 +27,25 @@ describe('Namespace', () => {
 
     expect(ns.a.b.c.ClassConstructor).toEqual(ClassConstructor);
   });
+
+  it('Should return undefined when creating namespace with wrong path format', () => {
+    expect(ns.namespace(false)).toEqual(undefined);
+    expect(ns.namespace(1)).toEqual(undefined);
+    expect(ns.namespace(null)).toEqual(undefined);
+    expect(ns.namespace(undefined)).toEqual(undefined);
+  });
+
+  it('Should return undefined when getting wrong path format namespace value', () => {
+    expect(ns.get(false)).toEqual(undefined);
+    expect(ns.get(1)).toEqual(undefined);
+    expect(ns.get(null)).toEqual(undefined);
+    expect(ns.get(undefined)).toEqual(undefined);
+  });
+
+  it('Should return undefined when setting wrong path format', () => {
+    expect(ns.set(false)).toEqual(undefined);
+    expect(ns.set(1)).toEqual(undefined);
+    expect(ns.set(null)).toEqual(undefined);
+    expect(ns.set(undefined)).toEqual(undefined);
+  });
 });

--- a/packages/core/src/namespace.js
+++ b/packages/core/src/namespace.js
@@ -54,10 +54,14 @@ export class Namespace {
 			namespaceWarningEmitted = true;
 		}*/
 
-    let self = this;
-    let levels = path.split('.');
+    const levels = this._resolvePathLevels(path);
+    if (!levels) {
+      return levels;
+    }
 
-    for (let levelName of levels) {
+    let self = this;
+
+    for (const levelName of levels) {
       if (!Object.prototype.hasOwnProperty.call(self, levelName)) {
         self[levelName] = {};
       }
@@ -87,20 +91,12 @@ export class Namespace {
    * @return {*} The value at the specified path in the namespace or undefined for any non-string path
    */
   get(path) {
-    if (!path || typeof path !== 'string') {
-      if ($Debug) {
-        console.error(
-          'namespace.get: path is not type of string: ',
-          typeof path,
-          path
-        );
-      }
-
-      return undefined;
+    const levels = this._resolvePathLevels(path);
+    if (!levels) {
+      return levels;
     }
 
     let self = this;
-    let levels = path.split('.');
 
     for (let level of levels) {
       if (!self[level]) {
@@ -120,11 +116,37 @@ export class Namespace {
    * @param {*} value
    */
   set(path, value) {
-    let levels = path.split('.');
+    const levels = this._resolvePathLevels(path);
+    if (!levels) {
+      return levels;
+    }
+
     const lastKey = levels.pop();
-    let namespace = this.namespace(levels.join('.'));
+    const namespace = this.namespace(levels.join('.'));
 
     namespace[lastKey] = value;
+  }
+
+  /**
+   * Resolve path levels from string
+   *
+   * @param {string} path The namespace path.
+   * @param {*} array of levels or undefined for not valid path
+   */
+  _resolvePathLevels(path) {
+    if (!path || typeof path !== 'string') {
+      if ($Debug) {
+        console.error(
+          'namespace.get: path is not type of string: ',
+          typeof path,
+          path
+        );
+      }
+
+      return undefined;
+    }
+
+    return path.split('.');
   }
 }
 

--- a/packages/core/src/namespace.js
+++ b/packages/core/src/namespace.js
@@ -81,12 +81,24 @@ export class Namespace {
   }
 
   /**
-   * Return value for the specified namespace path point.
+   * Return value for the specified namespace path point or undefined if path is not type of string
    *
-   * @param {string} path The namespace path to test.
-   * @return {*} The value at the specified path in the namespace.
+   * @param {string} path The namespace path to get.
+   * @return {*} The value at the specified path in the namespace or undefined for any non-string path
    */
   get(path) {
+    if (!path || typeof path !== 'string') {
+      if ($Debug) {
+        console.error(
+          'namespace.get: path is not type of string: ',
+          typeof path,
+          path
+        );
+      }
+
+      return undefined;
+    }
+
     let self = this;
     let levels = path.split('.');
 

--- a/packages/core/src/namespace.js
+++ b/packages/core/src/namespace.js
@@ -55,10 +55,6 @@ export class Namespace {
 		}*/
 
     const levels = this._resolvePathLevels(path);
-    if (!levels) {
-      return levels;
-    }
-
     let self = this;
 
     for (const levelName of levels) {
@@ -99,9 +95,6 @@ export class Namespace {
    */
   get(path) {
     const levels = this._resolvePathLevels(path);
-    if (!levels) {
-      return levels;
-    }
 
     let self = this;
 
@@ -124,9 +117,6 @@ export class Namespace {
    */
   set(path, value) {
     const levels = this._resolvePathLevels(path);
-    if (!levels) {
-      return levels;
-    }
 
     const lastKey = levels.pop();
     const namespace = this.namespace(levels.join('.'));
@@ -142,14 +132,6 @@ export class Namespace {
    */
   _resolvePathLevels(path) {
     if (!path || typeof path !== 'string') {
-      if ($Debug) {
-        console.error(
-          'namespace.get: path is not type of string: ',
-          typeof path,
-          path
-        );
-      }
-
       throw Error('namespace.get: path is not type of string');
     }
 

--- a/packages/core/src/namespace.js
+++ b/packages/core/src/namespace.js
@@ -81,7 +81,14 @@ export class Namespace {
    *         at the specified path.
    */
   has(path) {
-    return typeof this.get(path) !== 'undefined';
+    let hasPath;
+    try {
+      hasPath = this.get(path) !== undefined;
+    } catch (e) {
+      hasPath = false;
+    }
+
+    return hasPath;
   }
 
   /**
@@ -143,7 +150,7 @@ export class Namespace {
         );
       }
 
-      return undefined;
+      throw Error('namespace.get: path is not type of string');
     }
 
     return path.split('.');


### PR DESCRIPTION
The getter or namespace checks path argument for valid string before
performing path splitting. Getter logs error in Debug mode if path is
not type of string and returns undefined. Method has therefore returns
false on invalid path argument.