### PR TITLE
fix: 🐛 component fire method send data undefined by default

### DIFF
--- a/packages/core/src/page/AbstractComponent.js
+++ b/packages/core/src/page/AbstractComponent.js
@@ -102,7 +102,7 @@ export default class AbstractComponent extends React.Component {
    * @param {string} eventName The name of the event.
    * @param {*=} data Data to send within the event.
    */
-  fire(eventName, data = null) {
+  fire(eventName, data = undefined) {
     helpers.fire(this, eventName, data);
   }
 

--- a/packages/core/src/page/AbstractPureComponent.js
+++ b/packages/core/src/page/AbstractPureComponent.js
@@ -111,7 +111,7 @@ export default class AbstractPureComponent extends React.PureComponent {
    * @param {string} eventName The name of the event.
    * @param {*=} data Data to send within the event.
    */
-  fire(eventName, data = null) {
+  fire(eventName, data = undefined) {
     helpers.fire(this, eventName, data);
   }
 


### PR DESCRIPTION
Fire method sends data=undefined as default to allow object destructing
with default values in event callback argument