### PR TITLE
chore: 🤖 Fixed postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "verdaccio": "4.5.1"
   },
   "scripts": {
-    "postinstall": "npm install --prefix ./packages/devtools && lerna bootstrap --no-ci",
+    "postinstall": "npm install --prefix ./packages/devtools && lerna bootstrap",
     "benchmark": "utils/benchmark/benchmark.sh",
     "doc": "gulp doc",
     "test": "lerna run test && npm run --prefix ./packages/devtools test",


### PR DESCRIPTION
Reverts changes implemented in https://github.com/seznam/ima/commit/b4104cdd78a49c18d9a3196d9bac8e8cc86ecb99, which causes update of package-lock during publishing.