### PR TITLE
feat: 🎸 state transactions

### DIFF
--- a/docs/docs/page-state.md
+++ b/docs/docs/page-state.md
@@ -27,14 +27,14 @@ onVisibilityToggle() {
 ```
 
 ## Initial page state
-First additions to page state are set when `load` method of a Controller and Extensions returns an object of resources. These resources may be plain data or (un)resolved promises. Promises are handled differently on server vs. client. This behaviour is described in Controller's [`load` method documentation](/docs/controller-lifecycle#load-serverclient). 
+First additions to page state are set when `load` method of a Controller and Extensions returns an object of resources. These resources may be plain data or (un)resolved promises. Promises are handled differently on server vs. client. This behaviour is described in Controller's [`load` method documentation](/docs/controller-lifecycle#load-serverclient).
 
 ## Partial state
 Since Extensions also have a word in loading resources it may be necessary to share resources between Controller and Extensions. Here comes partial state into play. It allows you to call `getState` method in `load` method of an Extension. Received state consists of states collected from loaded Controller and Extensions loaded prior to the current Extension. Extensions are loaded in the same order as they were registered in a Controller.
 
 > **Note**: Promises in received state may not be resolved. Therefore you need to chain promises or use `async/await`.
 
-> **Note**: If you'll use `async/await` execution will not be parallel relative to other promises. 
+> **Note**: If you'll use `async/await` execution will not be parallel relative to other promises.
 
 ```javascript
 // app/page/home/HomeController.js
@@ -69,6 +69,53 @@ export default class PollExtension extends AbstractExtension {
   }
 }
 ```
+
+## State transactions
+
+State transactions, similarly to SQL transactions, provide a way to queue state patches and then commit them as a one to the original state.
+
+They're here for use cases where you'd in you workflow call `setState` method multiple times or you'd have to collect state patches in a separate variable (this is hard to do across multiple methods).
+
+Transaction is initiated with `beginStateTransaction()` in Controller/Extension. After that
+every setState call is queued and doesn't change the state or re-render anything. If there
+is another transaction initiated before you commit you'll lost your patches.
+
+To finish the transaction you have to call `commitStateTransaction()` method. It will squash
+all the patches made during the transaction into a one and apply it to the original state.
+Therefore your application will re-render only once and you'll also receive [state events](/docs/events#stateeventsbefore_change_state) only once.
+
+Another way to finish the transaction is to cancel it via `cancelStateTransaction()` method.
+
+> **Note**: Call to `getState` method after the transaction has begun will return state as it was before the transaction eg. the returned state doesn't include changes from the transaction period until the transaction is commited.
+
+```javascript
+async onFormSubmit({ content, deleteRevisions = false }) {
+  const { article } = this.getState();
+
+  this.beginStateTransaction();
+
+  const result = await this._http.put(/* ... */);
+
+  if (deleteRevisions) {
+    await this.deleteArtiacleRevisions();
+  }
+
+  this.setState({ article: Object.assign({}, article, { content }) });
+  this.commitStateTransaction();
+}
+
+async deleteArtiacleRevisions() {
+  const { article, revisions } = this.getState();
+
+  await this._http.delete(/* ... */);
+
+  this.setState({ revisions: [] });
+}
+```
+
+In the example above, after the form is submitted with `deleteRevisions = true`:
+ - Two `setState` calls are made
+ - Only one render is triggered after the `commitStateTransaction` call
 
 
 

--- a/packages/core/src/controller/AbstractController.js
+++ b/packages/core/src/controller/AbstractController.js
@@ -108,6 +108,33 @@ export default class AbstractController extends Controller {
   /**
    * @inheritdoc
    */
+  beginStateTransaction() {
+    if (this._pageStateManager) {
+      this._pageStateManager.beginTransaction();
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  commitStateTransaction() {
+    if (this._pageStateManager) {
+      this._pageStateManager.commitTransaction();
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  cancelStateTransaction() {
+    if (this._pageStateManager) {
+      this._pageStateManager.cancelTransaction();
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
   addExtension(extension) {
     this._extensions.push(extension);
   }

--- a/packages/core/src/controller/Controller.js
+++ b/packages/core/src/controller/Controller.js
@@ -154,6 +154,26 @@ export default class Controller {
   getState() {}
 
   /**
+   * Starts queueing state patches off the controller state. While the transaction
+   * is active every {@method setState} call has no effect on the current state.
+   *
+   * Note that call to {@method getState} after the transaction has begun will
+   * return state as it was before the transaction.
+   */
+  beginStateTransaction() {}
+
+  /**
+   * Applies queued state patches to the controller state. All patches are squashed
+   * and applied with one {@method setState} call.
+   */
+  commitStateTransaction() {}
+
+  /**
+   * Cancels ongoing state transaction. Uncommited state changes are lost.
+   */
+  cancelStateTransaction() {}
+
+  /**
    * Adds the provided extension to this controller. All extensions should be
    * added to the controller before the {@link Controller#init} method is
    * invoked.

--- a/packages/core/src/controller/ControllerDecorator.js
+++ b/packages/core/src/controller/ControllerDecorator.js
@@ -123,6 +123,27 @@ export default class ControllerDecorator extends Controller {
   /**
    * @inheritdoc
    */
+  beginStateTransaction() {
+    this.controller.beginStateTransaction();
+  }
+
+  /**
+   * @inheritdoc
+   */
+  commitStateTransaction() {
+    this._controller.commitStateTransaction();
+  }
+
+  /**
+   * @inheritdoc
+   */
+  cancelStateTransaction() {
+    this._controller.cancelStateTransaction();
+  }
+
+  /**
+   * @inheritdoc
+   */
   addExtension(extension) {
     this._controller.addExtension(extension);
 

--- a/packages/core/src/extension/AbstractExtension.js
+++ b/packages/core/src/extension/AbstractExtension.js
@@ -106,6 +106,33 @@ export default class AbstractExtension extends Extension {
   /**
    * @inheritdoc
    */
+  beginStateTransaction() {
+    if (this._pageStateManager) {
+      this._pageStateManager.beginTransaction();
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  commitStateTransaction() {
+    if (this._pageStateManager) {
+      this._pageStateManager.commitTransaction();
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  cancelStateTransaction() {
+    if (this._pageStateManager) {
+      this._pageStateManager.cancelTransaction();
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
   setPartialState(partialStatePatch) {
     const newPartialState = Object.assign(
       {},

--- a/packages/core/src/extension/Extension.js
+++ b/packages/core/src/extension/Extension.js
@@ -147,6 +147,26 @@ export default class Extension {
   getState() {}
 
   /**
+   * Starts queueing state patches off the controller state. While the transaction
+   * is active every {@method setState} call has no effect on the current state.
+   *
+   * Note that call to {@method getState} after the transaction has begun will
+   * return state as it was before the transaction.
+   */
+  beginStateTransaction() {}
+
+  /**
+   * Applies queued state patches to the controller state. All patches are squashed
+   * and applied with one {@method setState} call.
+   */
+  commitStateTransaction() {}
+
+  /**
+   * Cancels ongoing state transaction. Uncommited state changes are lost.
+   */
+  cancelStateTransaction() {}
+
+  /**
    * Patches the partial state of the extension. The extension is able
    * during its load and update phase receive state from active controller
    * using this extension and from previously loaded/updated extensions.

--- a/packages/core/src/page/state/PageStateManager.js
+++ b/packages/core/src/page/state/PageStateManager.js
@@ -32,4 +32,24 @@ export default class PageStateManager {
    * @return {Object<string, *>[]} The recorded history of page states.
    */
   getAllStates() {}
+
+  /**
+   * Starts queueing state patches off the main state. While the transaction
+   * is active every {@method setState} call has no effect on the current state.
+   *
+   * Note that call to {@method getState} after the transaction has begun will
+   * return state as it was before the transaction.
+   */
+  beginTransaction() {}
+
+  /**
+   * Applies queued state patches to the main state. All patches are squashed
+   * and applied with one {@method setState} call.
+   */
+  commitTransaction() {}
+
+  /**
+   * Cancels ongoing transaction. Uncommited state changes are lost.
+   */
+  cancelTransaction() {}
 }

--- a/packages/core/src/page/state/PageStateManagerImpl.js
+++ b/packages/core/src/page/state/PageStateManagerImpl.js
@@ -104,8 +104,9 @@ export default class PageStateManagerImpl extends PageStateManager {
     if ($Debug && this._ongoingTransaction) {
       console.warn(
         'ima.core.page.state.PageStateManagerImpl.beginTransaction():' +
-          'Another state transaction is already in progress. ' +
-          'Uncommited state changes will be lost. Check you workflow.'
+          'Another state transaction is already in progress. Check you workflow.' +
+          'These uncommited state changes will be lost:',
+        this._statePatchQueue
       );
     }
 

--- a/packages/core/src/page/state/PageStateManagerImpl.js
+++ b/packages/core/src/page/state/PageStateManagerImpl.js
@@ -125,10 +125,7 @@ export default class PageStateManagerImpl extends PageStateManager {
       );
     }
 
-    const finalPatch = this._statePatchQueue.reduce(
-      (state, patch) => Object.assign(state, patch),
-      {}
-    );
+    const finalPatch = Object.assign.apply({}, this._statePatchQueue);
 
     this._ongoingTransaction = false;
     this._statePatchQueue = [];

--- a/packages/core/src/page/state/PageStateManagerImpl.js
+++ b/packages/core/src/page/state/PageStateManagerImpl.js
@@ -125,8 +125,8 @@ export default class PageStateManagerImpl extends PageStateManager {
     }
 
     const finalPatch = this._statePatchQueue.reduce(
-      (state, patch) => Object.assign({}, state, patch),
-      this.getState()
+      (state, patch) => Object.assign(state, patch),
+      {}
     );
 
     this._ongoingTransaction = false;

--- a/packages/core/src/page/state/__tests__/PageStateManagerImplSpec.js
+++ b/packages/core/src/page/state/__tests__/PageStateManagerImplSpec.js
@@ -7,6 +7,8 @@ describe('ima.core.page.state.PageStateManagerImpl', () => {
   let stateManager = null;
   let defaultState = { state: 'state', patch: null };
   let patchState = { patch: 'patch' };
+  let queuedPatchState1 = { lazy: 'patch' };
+  let queuedPatchState2 = { queued: 'patch', lazy: 'overriden' };
   let dispatcher = toMockedInstance(Dispatcher);
 
   beforeEach(() => {
@@ -35,36 +37,108 @@ describe('ima.core.page.state.PageStateManagerImpl', () => {
   });
 
   describe('setState method', () => {
+    beforeEach(() => {
+      spyOn(stateManager, '_eraseExcessHistory').and.stub();
+      spyOn(stateManager, '_pushToHistory').and.stub();
+      spyOn(stateManager, '_callOnChangeCallback').and.callThrough();
+      spyOn(dispatcher, 'fire');
+    });
+
     it('should set smooth copy last state and state patch', () => {
       let newState = Object.assign({}, defaultState, patchState);
-
-      spyOn(stateManager, '_eraseExcessHistory').and.stub();
-
-      spyOn(stateManager, '_pushToHistory').and.stub();
-
-      spyOn(stateManager, '_callOnChangeCallback').and.callThrough();
-
-      spyOn(dispatcher, 'fire');
 
       stateManager.setState(patchState);
 
       expect(stateManager._eraseExcessHistory).toHaveBeenCalledWith();
       expect(stateManager._pushToHistory).toHaveBeenCalledWith(newState);
       expect(stateManager._callOnChangeCallback).toHaveBeenCalledWith(newState);
-      expect(dispatcher.fire).toHaveBeenCalledWith(
+      expect(dispatcher.fire).toHaveBeenNthCalledWith(
+        1,
         Events.BEFORE_CHANGE_STATE,
         { newState, patchState, oldState: defaultState },
         true
       );
-      expect(dispatcher.fire).toHaveBeenCalledWith(
+      expect(dispatcher.fire).toHaveBeenNthCalledWith(
+        2,
         Events.AFTER_CHANGE_STATE,
         { newState },
         true
       );
     });
+
+    it('should add the state patch to the queue during transaction', () => {
+      stateManager.beginTransaction();
+
+      stateManager.setState(patchState);
+
+      expect(stateManager._statePatchQueue).toHaveLength(1);
+      expect(stateManager._pushToHistory).not.toHaveBeenCalled();
+      expect(dispatcher.fire).not.toHaveBeenCalled();
+    });
   });
 
   it('should return history of states', () => {
     expect(stateManager.getAllStates()).toEqual([defaultState]);
+  });
+
+  describe('beginTransaction method', () => {
+    it('should show warning for another ongoing transaction', () => {
+      stateManager._ongoingTransaction = true;
+      spyOn(console, 'warn').and.stub();
+
+      stateManager.beginTransaction();
+
+      expect(console.warn).toHaveBeenCalled();
+    });
+
+    it('should flag transaction and empty queue', () => {
+      stateManager.beginTransaction();
+
+      expect(stateManager._ongoingTransaction).toBe(true);
+      expect(stateManager._statePatchQueue).toHaveLength(0);
+    });
+  });
+
+  describe('commitTransaction method', () => {
+    it('should show warning for no active transaction', () => {
+      stateManager._ongoingTransaction = false;
+      spyOn(console, 'warn').and.stub();
+
+      stateManager.commitTransaction();
+
+      expect(console.warn).toHaveBeenCalled();
+    });
+
+    it('should patch state with all the queued patches in order they were queued', () => {
+      const finalState = Object.assign(
+        {},
+        defaultState,
+        queuedPatchState1,
+        queuedPatchState2
+      );
+      stateManager.beginTransaction();
+
+      stateManager.setState(queuedPatchState1);
+      stateManager.setState(queuedPatchState2);
+
+      spyOn(stateManager, 'setState').and.callThrough();
+
+      stateManager.commitTransaction();
+
+      expect(stateManager.setState).toHaveBeenCalledWith(finalState);
+      expect(stateManager.getState().lazy).toEqual('overriden');
+    });
+  });
+
+  describe('cancelTransaction method', () => {
+    it('should cancel transaction and empty queue', () => {
+      stateManager.beginTransaction();
+      stateManager.setState(queuedPatchState1);
+
+      stateManager.cancelTransaction();
+
+      expect(stateManager._ongoingTransaction).toBe(false);
+      expect(stateManager._statePatchQueue).toHaveLength(0);
+    });
   });
 });

--- a/packages/core/src/page/state/__tests__/PageStateManagerImplSpec.js
+++ b/packages/core/src/page/state/__tests__/PageStateManagerImplSpec.js
@@ -1,5 +1,5 @@
 import PageStateManager from '../PageStateManagerImpl';
-import Dispatcher from 'src/event/Dispatcher';
+import Dispatcher from '../../../event/Dispatcher';
 import Events from '../Events';
 import { toMockedInstance } from 'to-mock';
 
@@ -112,7 +112,6 @@ describe('ima.core.page.state.PageStateManagerImpl', () => {
     it('should patch state with all the queued patches in order they were queued', () => {
       const finalState = Object.assign(
         {},
-        defaultState,
         queuedPatchState1,
         queuedPatchState2
       );


### PR DESCRIPTION
Ability to queue state patches and then commit them as a one to the
original state.

For use cases where you'd in you workflow call `setState` method multiple times or you'd have to collect state patches in a separate variable (this is hard to do across multiple methods).

1. Transaction is initiated with `beginTransaction()` method (or `beginStateTransaction()` in Controller/Extension).
2. From now on every `setState` call is queued and doesn't change the state or re-render anything.
3. Queue is applied with `commitTransaction()`/`commitStateTransaction()` method or emptied with `cancelTransaction()`/`cancelStateTransaction()` method.