### PR TITLE
fix: 🐛 extension update method receives full state

### DIFF
--- a/packages/core/src/page/manager/AbstractPageManager.js
+++ b/packages/core/src/page/manager/AbstractPageManager.js
@@ -545,19 +545,29 @@ export default class AbstractPageManager extends PageManager {
    */
   async _getUpdatedExtensionsState(controllerState) {
     const controller = this._managedPage.controllerInstance;
-    let extensionsState = Object.assign({}, controllerState);
+    const extensionsState = Object.assign({}, controllerState);
+    const extensionsPartialState = Object.assign(
+      {},
+      this._pageStateManager.getState(),
+      controllerState
+    );
 
     for (let extension of controller.getExtensions()) {
       const lastRouteParams = extension.getRouteParams();
       extension.setRouteParams(this._managedPage.params);
-      extension.setPartialState(extensionsState);
+      extension.setPartialState(extensionsPartialState);
       extension.switchToPartialState();
-      const extensionState = await extension.update(lastRouteParams);
 
-      this._switchToPageStateManagerAfterLoaded(extension, extensionState);
-      this._setRestrictedPageStateManager(extension, extensionState);
+      const extensionReturnedState = await extension.update(lastRouteParams);
 
-      Object.assign(extensionsState, extensionState);
+      this._switchToPageStateManagerAfterLoaded(
+        extension,
+        extensionReturnedState
+      );
+      this._setRestrictedPageStateManager(extension, extensionReturnedState);
+
+      Object.assign(extensionsState, extensionReturnedState);
+      Object.assign(extensionsPartialState, extensionReturnedState);
     }
 
     return extensionsState;

--- a/packages/core/src/page/manager/__tests__/AbstractPageManagerSpec.js
+++ b/packages/core/src/page/manager/__tests__/AbstractPageManagerSpec.js
@@ -532,10 +532,16 @@ describe('ima.core.page.manager.AbstractPageManager', () => {
       spyOn(extensionInstance, 'setPartialState').and.stub();
       spyOn(extensionInstance, 'switchToPartialState').and.stub();
       spyOn(extensionInstance, 'update').and.returnValue(extensionState);
+      spyOn(pageStateManager, 'getState').and.returnValue({ foo: 'bar' });
 
-      await pageManager._getUpdatedExtensionsState();
+      await pageManager._getUpdatedExtensionsState({ foobar: 'bazfoo' });
 
-      expect(extensionInstance.setPartialState).toHaveBeenCalled();
+      expect(extensionInstance.setPartialState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          foo: 'bar',
+          foobar: 'bazfoo'
+        })
+      );
       expect(extensionInstance.switchToPartialState).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
`update()` method of extension receives full page state extended by
partial state from controller and previous extensions

✅ Closes: #101