### PR TITLE
fix: 🐛 passing original params to not-found and error route

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1134,14 +1134,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@ima/helpers": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/@ima/helpers/-/helpers-17.9.0.tgz",
-      "integrity": "sha512-dIgE47fxUi/6vCZmC3VwPxawxsk4/n0oGp5lJnFJ/Jh8YTjp3lGyNBksT9WyMJZOLjKErYup8i22/ZWmnDjPlA==",
-      "requires": {
-        "clone": "^2.1.2"
-      }
-    },
     "@jsbits/escape-regex-str": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@jsbits/escape-regex-str/-/escape-regex-str-1.0.3.tgz",
@@ -2575,11 +2567,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       }
-    },
-    "clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
     },
     "clone-deep": {
       "version": "4.0.1",

--- a/packages/core/src/router/AbstractRouter.js
+++ b/packages/core/src/router/AbstractRouter.js
@@ -310,9 +310,9 @@ export default class AbstractRouter extends Router {
    * @inheritdoc
    */
   async handleError(params, options = {}, locals = {}) {
-    let routeError = this._routeHandlers.get(RouteNames.ERROR);
+    let errorRoute = this._routeHandlers.get(RouteNames.ERROR);
 
-    if (!routeError) {
+    if (!errorRoute) {
       let error = new GenericError(
         `ima.core.router.AbstractRouter:handleError cannot process the ` +
           `error because no error page route has been configured. Add ` +
@@ -323,33 +323,38 @@ export default class AbstractRouter extends Router {
       return Promise.reject(error);
     }
 
+    const originalPath = this._getCurrentlyRoutedPath();
+    const { route } = this._getRouteHandlersByPath(originalPath);
+
+    params = Object.assign({}, route.extractParameters(originalPath), params);
+
     const action = {
       url: this.getUrl(),
       type: ActionTypes.ERROR
     };
 
     locals.action = action;
-    locals.route = routeError;
+    locals.route = errorRoute;
 
     await this._runMiddlewares(
       [
         ...this._getMiddlewaresForRoute(RouteNames.ERROR),
-        ...routeError.getOptions().middlewares
+        ...errorRoute.getOptions().middlewares
       ],
       params,
       locals
     );
 
-    return this._handle(routeError, params, options, action);
+    return this._handle(errorRoute, params, options, action);
   }
 
   /**
    * @inheritdoc
    */
   async handleNotFound(params, options = {}, locals = {}) {
-    let routeNotFound = this._routeHandlers.get(RouteNames.NOT_FOUND);
+    let notFoundRoute = this._routeHandlers.get(RouteNames.NOT_FOUND);
 
-    if (!routeNotFound) {
+    if (!notFoundRoute) {
       let error = new GenericError(
         `ima.core.router.AbstractRouter:handleNotFound cannot processes ` +
           `a non-matching route because no not found page route has ` +
@@ -361,24 +366,29 @@ export default class AbstractRouter extends Router {
       return Promise.reject(error);
     }
 
+    const originalPath = this._getCurrentlyRoutedPath();
+    const { route } = this._getRouteHandlersByPath(originalPath);
+
+    params = Object.assign({}, route.extractParameters(originalPath), params);
+
     const action = {
       url: this.getUrl(),
       type: ActionTypes.ERROR
     };
 
     locals.action = action;
-    locals.route = routeNotFound;
+    locals.route = notFoundRoute;
 
     await this._runMiddlewares(
       [
         ...this._getMiddlewaresForRoute(RouteNames.NOT_FOUND),
-        ...routeNotFound.getOptions().middlewares
+        ...notFoundRoute.getOptions().middlewares
       ],
       params,
       locals
     );
 
-    return this._handle(routeNotFound, params, options, action);
+    return this._handle(notFoundRoute, params, options, action);
   }
 
   /**

--- a/packages/core/src/router/AbstractRouter.js
+++ b/packages/core/src/router/AbstractRouter.js
@@ -323,10 +323,7 @@ export default class AbstractRouter extends Router {
       return Promise.reject(error);
     }
 
-    const originalPath = this._getCurrentlyRoutedPath();
-    const { route } = this._getRouteHandlersByPath(originalPath);
-
-    params = Object.assign({}, route.extractParameters(originalPath), params);
+    params = this._addParamsFromOriginalRoute(params);
 
     const action = {
       url: this.getUrl(),
@@ -366,10 +363,7 @@ export default class AbstractRouter extends Router {
       return Promise.reject(error);
     }
 
-    const originalPath = this._getCurrentlyRoutedPath();
-    const { route } = this._getRouteHandlersByPath(originalPath);
-
-    params = Object.assign({}, route.extractParameters(originalPath), params);
+    params = this._addParamsFromOriginalRoute(params);
 
     const action = {
       url: this.getUrl(),
@@ -572,5 +566,25 @@ export default class AbstractRouter extends Router {
     for (const middleware of middlewares) {
       await middleware.run(params, locals);
     }
+  }
+
+  /**
+   * Obtains original route that was handled before not-found / error route
+   * and assigns its params to current params
+   *
+   * @param {Object<string, string>} params Route params for not-found or
+   *        error page
+   * @returns {Object<string, string>} Provided params merged with params
+   *        from original route
+   */
+  _addParamsFromOriginalRoute(params) {
+    const originalPath = this._getCurrentlyRoutedPath();
+    const { route } = this._getRouteHandlersByPath(originalPath);
+
+    if (!route) {
+      return params;
+    }
+
+    return Object.assign({}, route.extractParameters(originalPath), params);
   }
 }

--- a/packages/core/src/router/__tests__/AbstractRouterSpec.js
+++ b/packages/core/src/router/__tests__/AbstractRouterSpec.js
@@ -271,6 +271,7 @@ describe('ima.core.router.AbstractRouter', () => {
   describe('handleError method', () => {
     let path = '/error';
     let route = null;
+    let originalRoute = null;
     let routeMiddleware = jest.fn();
 
     beforeEach(() => {
@@ -284,6 +285,15 @@ describe('ima.core.router.AbstractRouter', () => {
           middlewares: [routeMiddleware]
         }
       );
+
+      originalRoute = routeFactory.createRoute(
+        'user',
+        '/user/:userId',
+        Controller,
+        View
+      );
+
+      router._currentlyRoutedPath = '/user/2345';
     });
 
     afterEach(() => {
@@ -294,6 +304,9 @@ describe('ima.core.router.AbstractRouter', () => {
       let params = { error: new Error('test') };
 
       spyOn(router._routeHandlers, 'get').and.returnValue(route);
+      spyOn(router, '_getRouteHandlersByPath').and.returnValue({
+        route: originalRoute
+      });
       spyOn(router, '_runMiddlewares').and.callThrough();
 
       spyOn(router, '_handle').and.returnValue(
@@ -309,7 +322,10 @@ describe('ima.core.router.AbstractRouter', () => {
         .then(response => {
           expect(router._handle).toHaveBeenCalledWith(
             route,
-            params,
+            expect.objectContaining({
+              ...params,
+              userId: '2345'
+            }),
             options,
             errorAction
           );
@@ -319,7 +335,10 @@ describe('ima.core.router.AbstractRouter', () => {
               new RouterMiddleware(globalMiddleware),
               new RouterMiddleware(routeMiddleware)
             ],
-            params,
+            expect.objectContaining({
+              ...params,
+              userId: '2345'
+            }),
             { route, action: errorAction }
           );
           done();
@@ -345,6 +364,7 @@ describe('ima.core.router.AbstractRouter', () => {
   describe('handleNotFound method', () => {
     let path = '/not-found';
     let route = null;
+    let originalRoute = null;
     let routeMiddleware = jest.fn();
 
     beforeEach(() => {
@@ -358,6 +378,15 @@ describe('ima.core.router.AbstractRouter', () => {
           middlewares: [routeMiddleware]
         }
       );
+
+      originalRoute = routeFactory.createRoute(
+        'user',
+        '/user/:userId',
+        Controller,
+        View
+      );
+
+      router._currentlyRoutedPath = '/user/2345';
     });
 
     afterEach(() => {
@@ -368,6 +397,9 @@ describe('ima.core.router.AbstractRouter', () => {
       let params = { error: new GenericError() };
 
       spyOn(router._routeHandlers, 'get').and.returnValue(route);
+      spyOn(router, '_getRouteHandlersByPath').and.returnValue({
+        route: originalRoute
+      });
       spyOn(router, '_runMiddlewares').and.callThrough();
 
       spyOn(router, '_handle').and.returnValue(
@@ -383,7 +415,10 @@ describe('ima.core.router.AbstractRouter', () => {
         .then(response => {
           expect(router._handle).toHaveBeenCalledWith(
             route,
-            params,
+            expect.objectContaining({
+              ...params,
+              userId: '2345'
+            }),
             options,
             errorAction
           );
@@ -393,7 +428,10 @@ describe('ima.core.router.AbstractRouter', () => {
               new RouterMiddleware(globalMiddleware),
               new RouterMiddleware(routeMiddleware)
             ],
-            params,
+            expect.objectContaining({
+              ...params,
+              userId: '2345'
+            }),
             { route, action: errorAction }
           );
           done();
@@ -684,9 +722,9 @@ describe('ima.core.router.AbstractRouter', () => {
     it('should return correct set of middlewares', () => {
       expect(middlewareRouter._routeHandlers.size).toBe(5);
 
-      expect(middlewareRouter._getRouteHandlersByPath('/').middlewares).toEqual(
-        [new RouterMiddleware(globalMiddleware)]
-      );
+      expect(
+        middlewareRouter._getRouteHandlersByPath('/').middlewares
+      ).toEqual([new RouterMiddleware(globalMiddleware)]);
 
       expect(
         middlewareRouter._getRouteHandlersByPath('/contact').middlewares

--- a/packages/core/src/router/__tests__/AbstractRouterSpec.js
+++ b/packages/core/src/router/__tests__/AbstractRouterSpec.js
@@ -722,9 +722,9 @@ describe('ima.core.router.AbstractRouter', () => {
     it('should return correct set of middlewares', () => {
       expect(middlewareRouter._routeHandlers.size).toBe(5);
 
-      expect(
-        middlewareRouter._getRouteHandlersByPath('/').middlewares
-      ).toEqual([new RouterMiddleware(globalMiddleware)]);
+      expect(middlewareRouter._getRouteHandlersByPath('/').middlewares).toEqual(
+        [new RouterMiddleware(globalMiddleware)]
+      );
 
       expect(
         middlewareRouter._getRouteHandlersByPath('/contact').middlewares

--- a/packages/gulp-tasks/package-lock.json
+++ b/packages/gulp-tasks/package-lock.json
@@ -1062,15 +1062,6 @@
         }
       }
     },
-    "@ima/helpers": {
-      "version": "17.7.9",
-      "resolved": "https://registry.npmjs.org/@ima/helpers/-/helpers-17.7.9.tgz",
-      "integrity": "sha512-P3kGLsvwWD+VxfpMMsd86mzGo7jdSCl9QJJpmunsr4LyUoQsYdbP6ASmm3ltTxYFXgLlIwATjIHJj4CkMDmF/w==",
-      "dev": true,
-      "requires": {
-        "clone": "^2.1.2"
-      }
-    },
     "@ima/plugin-websocket": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@ima/plugin-websocket/-/plugin-websocket-0.1.2.tgz",

--- a/packages/server/package-lock.json
+++ b/packages/server/package-lock.json
@@ -14,23 +14,6 @@
         "keypather": "^1.10.2"
       }
     },
-    "@ima/helpers": {
-      "version": "17.7.9",
-      "resolved": "https://registry.npmjs.org/@ima/helpers/-/helpers-17.7.9.tgz",
-      "integrity": "sha512-P3kGLsvwWD+VxfpMMsd86mzGo7jdSCl9QJJpmunsr4LyUoQsYdbP6ASmm3ltTxYFXgLlIwATjIHJj4CkMDmF/w==",
-      "dev": true,
-      "requires": {
-        "clone": "^2.1.2"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-          "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-          "dev": true
-        }
-      }
-    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",


### PR DESCRIPTION
When not-found or error route is handled instead of original route all
former params were lost. This caused trouble when params contained
application-wide info that was required even for the not-found or error
page.