### PR TITLE
feat: 🎸 Enable setting headers for redirects

### DIFF
--- a/packages/core/src/router/Response.js
+++ b/packages/core/src/router/Response.js
@@ -111,6 +111,7 @@ export default class Response {
    * @param {string} url The URL to which the client should be redirected.
    * @param {number=} [status=302] The HTTP status code to send to the
    *        client.
+   * @param {Object.<string, string>} [headers={}] Custom headers to be used on the response.
    * @return {Response} This response.
    */
   redirect(url, status = 302, headers = {}) {

--- a/packages/core/src/router/Response.js
+++ b/packages/core/src/router/Response.js
@@ -113,7 +113,8 @@ export default class Response {
    *        client.
    * @return {Response} This response.
    */
-  redirect(url, status = 302) {
+  redirect(url, status = 302, headers = {}) {
+    // TODO IMA@18 refactor to use an `options` object for `status` and `headers`, same as $Router
     if ($Debug) {
       if (this._isSent === true) {
         let params = this.getResponseParams();
@@ -130,6 +131,7 @@ export default class Response {
     this._isSent = true;
     this._status = status;
     this._setCookieHeaders();
+    this._response.set(headers);
     this._response.redirect(status, url);
 
     return this;

--- a/packages/core/src/router/Router.js
+++ b/packages/core/src/router/Router.js
@@ -241,7 +241,8 @@ export default class Router {
    *          allowSPA: boolean=,
    *          documentView: ?AbstractDocumentView=,
    *          managedRootView: ?function(new: React.Component)=,
-   *          viewAdapter: ?function(new: React.Component)=
+   *          viewAdapter: ?function(new: React.Component)=,
+   *          headers: Object<string, *>
    *        }} [options={}] The options overrides route options defined in
    *        the {@code routes.js} configuration file.
    * @param {{ type: string, payload: Object|Event }} [action] An action object

--- a/packages/core/src/router/ServerRouter.js
+++ b/packages/core/src/router/ServerRouter.js
@@ -68,7 +68,7 @@ export default class ServerRouter extends AbstractRouter {
    * @inheritdoc
    */
   redirect(url = '/', options = {}) {
-    this._response.redirect(url, options.httpStatus || 302);
+    this._response.redirect(url, options.httpStatus || 302, options.headers);
   }
   //#endif
 }

--- a/packages/core/src/router/__tests__/ResponseSpec.js
+++ b/packages/core/src/router/__tests__/ResponseSpec.js
@@ -21,4 +21,30 @@ describe('ima.core.router.Response', () => {
     expect(options.maxAge).toEqual(null);
     expect(expressOptions.maxAge).toBeUndefined();
   });
+
+  describe('redirect', () => {
+    it('should set cookies, headers, and redirect', () => {
+      response._response = {
+        cookie: jest.fn(),
+        redirect: jest.fn(),
+        set: jest.fn()
+      };
+      response._internalCookieStorage = new Map([
+        ['key1', 'value1'],
+        ['key2', 'value2'],
+        ['key3', 'value3']
+      ]);
+
+      const url = 'some/url/or/other';
+      const headers = {
+        'Custom-header': 'Some value'
+      };
+
+      response.redirect(url, 303, headers);
+
+      expect(response._response.set).toHaveBeenCalledWith(headers);
+      expect(response._response.cookie).toHaveBeenCalledTimes(3);
+      expect(response._response.redirect).toHaveBeenCalledWith(303, url);
+    });
+  });
 });

--- a/packages/core/src/router/__tests__/ServerRouterSpec.js
+++ b/packages/core/src/router/__tests__/ServerRouterSpec.js
@@ -40,12 +40,17 @@ describe('ima.core.router.ServerRouter', () => {
 
   it('should be redirect to url', () => {
     var url = domain + '/redirectUrl';
-    var options = { httpStatus: 303 };
+    var options = {
+      httpStatus: 303,
+      headers: { 'Custom-header': 'Some custom value' }
+    };
 
     spyOn(response, 'redirect').and.stub();
 
     router.redirect(url, options);
 
-    expect(response.redirect).toHaveBeenCalledWith(url, 303);
+    expect(response.redirect).toHaveBeenCalledWith(url, 303, {
+      'Custom-header': 'Some custom value'
+    });
   });
 });

--- a/packages/server/lib/clientApp.js
+++ b/packages/server/lib/clientApp.js
@@ -333,9 +333,10 @@ module.exports = (environment, logger, languageLoader, appFactory) => {
     let promise;
 
     try {
-      app.oc
-        .get('$Router')
-        .redirect(error.getParams().url, { httpStatus: error.getHttpStatus() });
+      app.oc.get('$Router').redirect(error.getParams().url, {
+        httpStatus: error.getHttpStatus(),
+        headers: error.getParams().headers
+      });
       instanceRecycler.clearInstance(app);
       promise = Promise.resolve({
         content: null,


### PR DESCRIPTION
The `Response.redirect` method now can set not only HTTP status, but
also any arbitrary headers.