### PR TITLE
feat: 🎸 Changed regex in Dictionary has() function + added test

### DIFF
--- a/packages/core/src/dictionary/MessageFormatDictionary.js
+++ b/packages/core/src/dictionary/MessageFormatDictionary.js
@@ -116,7 +116,7 @@ export default class MessageFormatDictionary extends Dictionary {
    *                   localization phrase, otherwise `false`.
    */
   has(key) {
-    if (!/^[^.]+\.[^.]+$/.test(key)) {
+    if (!/^[^.]+(\.[^.]+)+$/.test(key)) {
       throw new Error(
         `The provided key (${key}) is not a valid localization ` +
           `phrase key, expecting a "file_name.identifier" notation`

--- a/packages/core/src/dictionary/__tests__/MessageFormatSpec.js
+++ b/packages/core/src/dictionary/__tests__/MessageFormatSpec.js
@@ -8,6 +8,9 @@ describe('ima.core.dictionary.MessageFormatDictionary', () => {
       home: {
         title: () => 'title',
         message: () => 'message',
+        message2: {
+          title: () => 'title',
+        },
       },
     },
   };
@@ -45,10 +48,12 @@ describe('ima.core.dictionary.MessageFormatDictionary', () => {
     it('should be return true', () => {
       expect(dictionary.has('home.title')).toBe(true);
       expect(dictionary.has('home.message')).toBe(true);
+      expect(dictionary.has('home.message2.title')).toBe(true);
     });
 
     it('should be return false for non existing keys', () => {
       expect(dictionary.has('home.non-exists-phrase')).toBe(false);
+      expect(dictionary.has('home.message2.non-exist-phrase')).toBe(false);
     });
 
     it('should be throw Error for key not referring to a localization phrase', () => {


### PR DESCRIPTION
regex is changed to allow immersion in dictionary, new tests are
covering this feature, pull request is associated with [issue #195](https://github.com/seznam/ima/issues/195)