### PR TITLE
fix: 🐛 Replaced source-map with source-map-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22382,7 +22382,8 @@
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "dev": true
     },
     "node_modules/lodash.template": {
       "version": "4.5.0",
@@ -34338,16 +34339,16 @@
     },
     "packages/cli": {
       "name": "@ima/cli",
-      "version": "18.0.0-rc.0-next",
+      "version": "18.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.18.2",
         "@babel/preset-env": "^7.18.2",
         "@babel/preset-react": "^7.17.12",
         "@gatsbyjs/webpack-hot-middleware": "2.25.2",
-        "@ima/dev-utils": "18.0.0-rc.0-next",
-        "@ima/error-overlay": "18.0.0-rc.0-next",
-        "@ima/hmr-client": "18.0.0-rc.0-next",
+        "@ima/dev-utils": "^18.0.0-rc.1",
+        "@ima/error-overlay": "^18.0.0-rc.1",
+        "@ima/hmr-client": "^18.0.0-rc.1",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
         "@swc/core": "^1.2.196",
         "ajv": "8.11.0",
@@ -34403,7 +34404,7 @@
         "@types/yargs": "^17.0.10"
       },
       "peerDependencies": {
-        "@ima/server": "18.0.0-rc.0-next"
+        "@ima/server": "^18.0.0-rc.0"
       }
     },
     "packages/cli/node_modules/@gatsbyjs/webpack-hot-middleware": {
@@ -34534,10 +34535,10 @@
     },
     "packages/core": {
       "name": "@ima/core",
-      "version": "18.0.0-rc.0-next",
+      "version": "18.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
-        "@ima/helpers": "18.0.0-rc.0-next",
+        "@ima/helpers": "^18.0.0-rc.1",
         "classnames": "^2.3.1",
         "memoize-one": "^6.0.0"
       },
@@ -34553,7 +34554,7 @@
       }
     },
     "packages/create-ima-app": {
-      "version": "18.0.0-rc.0",
+      "version": "18.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.0.1",
@@ -34576,12 +34577,12 @@
     },
     "packages/dev-utils": {
       "name": "@ima/dev-utils",
-      "version": "18.0.0-rc.0-next",
+      "version": "18.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "cli-highlight": "^2.1.11",
-        "source-map": "0.8.0-beta.0",
+        "source-map-js": "^1.0.2",
         "stacktrace-parser": "^0.1.10",
         "strip-ansi": "^6.0.1"
       },
@@ -34590,40 +34591,6 @@
       },
       "peerDependencies": {
         "webpack": "^5.70.0"
-      }
-    },
-    "packages/dev-utils/node_modules/source-map": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-      "dependencies": {
-        "whatwg-url": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "packages/dev-utils/node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "packages/dev-utils/node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
-    },
-    "packages/dev-utils/node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
       }
     },
     "packages/devtools": {
@@ -34657,7 +34624,7 @@
     },
     "packages/devtools-scripts": {
       "name": "@ima/devtools-scripts",
-      "version": "18.0.0-rc.0",
+      "version": "18.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "to-aop": "^0.5.4"
@@ -34690,10 +34657,10 @@
     },
     "packages/error-overlay": {
       "name": "@ima/error-overlay",
-      "version": "18.0.0-rc.0-next",
+      "version": "18.0.0-rc.1",
       "license": "MIT",
       "devDependencies": {
-        "@ima/dev-utils": "18.0.0-rc.0-next",
+        "@ima/dev-utils": "^18.0.0-rc.1",
         "@types/prismjs": "^1.26.0",
         "@types/react": "^18.0.9",
         "@types/react-dom": "^18.0.5",
@@ -34702,7 +34669,6 @@
         "prismjs": "^1.28.0",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
-        "source-map": "0.8.0-beta.0",
         "stacktrace-parser": "^0.1.10"
       }
     },
@@ -34760,47 +34726,9 @@
         "loose-envify": "^1.1.0"
       }
     },
-    "packages/error-overlay/node_modules/source-map": {
-      "version": "0.8.0-beta.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-      "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^7.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "packages/error-overlay/node_modules/tr46": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "packages/error-overlay/node_modules/webidl-conversions": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
-    },
-    "packages/error-overlay/node_modules/whatwg-url": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-      "dev": true,
-      "dependencies": {
-        "lodash.sortby": "^4.7.0",
-        "tr46": "^1.0.1",
-        "webidl-conversions": "^4.0.2"
-      }
-    },
     "packages/helpers": {
       "name": "@ima/helpers",
-      "version": "18.0.0-rc.0-next",
+      "version": "18.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "clone": "^2.1.2"
@@ -34808,20 +34736,20 @@
     },
     "packages/hmr-client": {
       "name": "@ima/hmr-client",
-      "version": "18.0.0-rc.0-next",
+      "version": "18.0.0-rc.1",
       "license": "MIT",
       "devDependencies": {
-        "@ima/dev-utils": "18.0.0-rc.0-next",
+        "@ima/dev-utils": "^18.0.0-rc.1",
         "@types/webpack-env": "^1.16.3"
       },
       "peerDependencies": {
-        "@ima/dev-utils": "18.0.0-rc.0-next",
+        "@ima/dev-utils": "^18.0.0-rc.0",
         "webpack": "^5.70.0"
       }
     },
     "packages/server": {
       "name": "@ima/server",
-      "version": "18.0.0-rc.0-next",
+      "version": "18.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "ejs": "^3.1.6",
@@ -34829,12 +34757,12 @@
         "winston": "^3.6.0"
       },
       "devDependencies": {
-        "@ima/dev-utils": "18.0.0-rc.0-next",
+        "@ima/dev-utils": "^18.0.0-rc.1",
         "express": "^4.17.3"
       },
       "peerDependencies": {
-        "@ima/dev-utils": "18.0.0-rc.0-next",
-        "@ima/helpers": "18.0.0-rc.0-next"
+        "@ima/dev-utils": "^18.0.0-rc.0",
+        "@ima/helpers": "^18.0.0-rc.0"
       }
     }
   },
@@ -36661,9 +36589,9 @@
         "@babel/preset-env": "^7.18.2",
         "@babel/preset-react": "^7.17.12",
         "@gatsbyjs/webpack-hot-middleware": "2.25.2",
-        "@ima/dev-utils": "18.0.0-rc.0-next",
-        "@ima/error-overlay": "18.0.0-rc.0-next",
-        "@ima/hmr-client": "18.0.0-rc.0-next",
+        "@ima/dev-utils": "^18.0.0-rc.1",
+        "@ima/error-overlay": "^18.0.0-rc.1",
+        "@ima/hmr-client": "^18.0.0-rc.1",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
         "@swc/core": "^1.2.196",
         "@types/cli-progress": "^3.11.0",
@@ -36690,7 +36618,7 @@
         "express": "^4.18.1",
         "express-static-gzip": "^2.1.7",
         "globby": "11.1.0",
-        "kill-port": "1.6.1",
+        "kill-port": "^1.6.1",
         "less": "4.1.2",
         "less-loader": "^11.0.0",
         "messageformat": "2.3.0",
@@ -36710,7 +36638,7 @@
         "webpack": "^5.72.1",
         "webpack-bundle-analyzer": "4.5.0",
         "webpack-dev-middleware": "^5.3.3",
-        "whatwg-fetch": "*",
+        "whatwg-fetch": "^3.6.2",
         "yargs": "^17.5.1"
       },
       "dependencies": {
@@ -36792,7 +36720,7 @@
     "@ima/core": {
       "version": "file:packages/core",
       "requires": {
-        "@ima/helpers": "18.0.0-rc.0-next",
+        "@ima/helpers": "^18.0.0-rc.1",
         "@size-limit/preset-big-lib": "^7.0.8",
         "classnames": "^2.3.1",
         "enzyme": "^3.11.0",
@@ -36807,42 +36735,9 @@
         "@types/node": "^17.0.21",
         "chalk": "^4.1.2",
         "cli-highlight": "^2.1.11",
-        "source-map": "0.8.0-beta.0",
+        "source-map-js": "^1.0.2",
         "stacktrace-parser": "^0.1.10",
         "strip-ansi": "^6.0.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.8.0-beta.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-          "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-          "requires": {
-            "whatwg-url": "^7.0.0"
-          }
-        },
-        "tr46": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
-        "webidl-conversions": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
-        },
-        "whatwg-url": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-          "requires": {
-            "lodash.sortby": "^4.7.0",
-            "tr46": "^1.0.1",
-            "webidl-conversions": "^4.0.2"
-          }
-        }
       }
     },
     "@ima/devtools": {
@@ -36908,7 +36803,7 @@
     "@ima/error-overlay": {
       "version": "file:packages/error-overlay",
       "requires": {
-        "@ima/dev-utils": "18.0.0-rc.0-next",
+        "@ima/dev-utils": "^18.0.0-rc.1",
         "@types/prismjs": "^1.26.0",
         "@types/react": "^18.0.9",
         "@types/react-dom": "^18.0.5",
@@ -36917,7 +36812,6 @@
         "prismjs": "^1.28.0",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
-        "source-map": "0.8.0-beta.0",
         "stacktrace-parser": "^0.1.10"
       },
       "dependencies": {
@@ -36965,41 +36859,6 @@
           "requires": {
             "loose-envify": "^1.1.0"
           }
-        },
-        "source-map": {
-          "version": "0.8.0-beta.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-          "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-          "dev": true,
-          "requires": {
-            "whatwg-url": "^7.0.0"
-          }
-        },
-        "tr46": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-          "dev": true,
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
-        "webidl-conversions": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-          "dev": true
-        },
-        "whatwg-url": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-          "dev": true,
-          "requires": {
-            "lodash.sortby": "^4.7.0",
-            "tr46": "^1.0.1",
-            "webidl-conversions": "^4.0.2"
-          }
         }
       }
     },
@@ -37012,14 +36871,14 @@
     "@ima/hmr-client": {
       "version": "file:packages/hmr-client",
       "requires": {
-        "@ima/dev-utils": "18.0.0-rc.0-next",
+        "@ima/dev-utils": "^18.0.0-rc.1",
         "@types/webpack-env": "^1.16.3"
       }
     },
     "@ima/server": {
       "version": "file:packages/server",
       "requires": {
-        "@ima/dev-utils": "18.0.0-rc.0-next",
+        "@ima/dev-utils": "^18.0.0-rc.1",
         "ejs": "^3.1.6",
         "error-to-json": "^2.0.0",
         "express": "^4.17.3",
@@ -52321,7 +52180,8 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "dev": true
     },
     "lodash.template": {
       "version": "4.5.0",

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "chalk": "^4.1.2",
     "cli-highlight": "^2.1.11",
-    "source-map": "0.8.0-beta.0",
+    "source-map-js": "^1.0.2",
     "stacktrace-parser": "^0.1.10",
     "strip-ansi": "^6.0.1"
   },

--- a/packages/dev-utils/src/sourceMapUtils.ts
+++ b/packages/dev-utils/src/sourceMapUtils.ts
@@ -2,6 +2,7 @@ import { RE_SOURCE_MAPPING_URL } from './helpers';
 
 /**
  * Extracts sourceMappingURL from the provided file contents.
+ * Based on https://github.com/facebook/create-react-app/blob/main/packages/react-error-overlay/src/utils/getSourceMap.js#L79.
  *
  * @param {string} fileUri The uri of the source file.
  * @param {string} fileContents Source file file contents.

--- a/packages/error-overlay/package.json
+++ b/packages/error-overlay/package.json
@@ -35,7 +35,6 @@
     "prismjs": "^1.28.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
-    "source-map": "0.8.0-beta.0",
     "stacktrace-parser": "^0.1.10"
   },
   "publishConfig": {

--- a/packages/error-overlay/src/entities/SourceStorage.ts
+++ b/packages/error-overlay/src/entities/SourceStorage.ts
@@ -1,5 +1,5 @@
 import { extractSourceMappingUrl } from '@ima/dev-utils/dist/sourceMapUtils';
-import { RawSourceMap, SourceMapConsumer } from 'source-map';
+import { RawSourceMap, SourceMapConsumer } from 'source-map-js';
 
 interface SourceStorageEntry {
   rootDir?: string;
@@ -79,19 +79,9 @@ class SourceStorage {
   }
 
   /**
-   * Empties loaded sources and destroys allocated source maps.
+   * Empties loaded sources maps.
    */
   async cleanup(): Promise<void> {
-    for (const source of this._sourceStorage.values()) {
-      const loadedSource = await source;
-
-      if (!loadedSource || !loadedSource.sourceMap) {
-        continue;
-      }
-
-      loadedSource.sourceMap?.destroy();
-    }
-
     this._sourceStorage.clear();
   }
 

--- a/packages/error-overlay/src/hooks/useConnect.ts
+++ b/packages/error-overlay/src/hooks/useConnect.ts
@@ -1,6 +1,5 @@
 import { parseCompileError } from '@ima/dev-utils/dist/compileErrorParser';
 import { useContext, useEffect, useState } from 'react';
-import { SourceMapConsumer } from 'source-map';
 
 import { OverlayContext } from '@/components';
 import { SourceStorage } from '@/entities';
@@ -20,12 +19,6 @@ function useConnect(serverError: string | null) {
 
   // Subscribe to HMR events
   useEffect(() => {
-    // Needed to enable source map parsing
-    // @ts-expect-error: Not available in typings
-    SourceMapConsumer.initialize({
-      'lib/mappings.wasm': `${publicUrl}/__error-overlay-static/mappings.wasm`,
-    });
-
     // Parse server error
     (async () => {
       if (!serverError) {
@@ -122,7 +115,7 @@ function useConnect(serverError: string | null) {
             });
           }
 
-          // Cleanup wasm allocated sourcemaps
+          // Cleanup sources to force latest on next load
           sourceStorage.cleanup();
         } catch (err) {
           console.error('Unable to parse an error in ima-error-overlay.');

--- a/packages/error-overlay/webpack.config.js
+++ b/packages/error-overlay/webpack.config.js
@@ -1,7 +1,4 @@
-const path = require('path');
-
 const CompressionPlugin = require('compression-webpack-plugin');
-const CopyPlugin = require('copy-webpack-plugin');
 
 const { createWebpackConfig } = require('../../createWebpackConfig');
 
@@ -19,16 +16,6 @@ module.exports = createWebpackConfig(baseConfig => {
         },
         threshold: 0,
         minRatio: 0.95,
-      }),
-      new CopyPlugin({
-        patterns: [
-          {
-            from: path.join(
-              path.dirname(require.resolve('source-map')),
-              'lib/mappings.wasm'
-            ),
-          },
-        ],
       }),
     ].filter(Boolean),
   };


### PR DESCRIPTION
Fixes issues with node18 parsing errors and eliminates the need to
handle wasm initcialization