### PR TITLE
feat: 🎸 Improved code splitting and swc config

### DIFF
--- a/packages/cli/src/plugins/less-constants/LessConstantsPlugin.ts
+++ b/packages/cli/src/plugins/less-constants/LessConstantsPlugin.ts
@@ -104,7 +104,7 @@ class LessConstantsPlugin implements ImaCliPlugin {
     return new Promise((resolve, reject) => {
       webpack(
         {
-          target: 'node16',
+          target: 'node18',
           mode: 'none',
           output: {
             path: outputDir,

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -195,7 +195,6 @@ export type ImaConfig = {
    */
   experiments?: {
     swc?: boolean; // Enables swc instead of babel (true by default)
-    swcMinimizer?: boolean; // Enables swc minimizer
     css?: boolean; // Enables webpack native CSS support
   };
 };

--- a/packages/cli/src/webpack/config.ts
+++ b/packages/cli/src/webpack/config.ts
@@ -357,7 +357,14 @@ export default async (
                    */
                   {
                     test: /\.(js|mjs|cjs)$/,
-                    exclude: [/\bcore-js\b/, /\bwebpack\/buildin\b/, appDir],
+                    exclude: [
+                      /\bcore-js\b/,
+                      /\bwebpack\/buildin\b/,
+                      /\bcss-loader\b/,
+                      /\bmini-css-extract-plugin\b/,
+                      /\breact-dom-server\b/,
+                      appDir,
+                    ],
                     use: [
                       !isServer && {
                         loader: require.resolve('swc-loader'),
@@ -369,7 +376,7 @@ export default async (
                             bugfixes: true,
                           },
                           module: {
-                            type: 'commonjs',
+                            type: 'es6',
                           },
                           jsc: {
                             parser: {

--- a/packages/cli/src/webpack/config.ts
+++ b/packages/cli/src/webpack/config.ts
@@ -211,9 +211,13 @@ export default async (
 
         return `${baseFolder}/${fileNameParts.join('.')}`;
       },
+      chunkFilename: () =>
+        isServer
+          ? `server/chunk.[id].js`
+          : `static/${isEsVersion ? 'js.es' : 'js'}/chunk.[id].js`,
       cssFilename: ({ chunk }) =>
         `static/css/${chunk?.name === name ? 'app' : '[name]'}.css`,
-      cssChunkFilename: `static/css/[id].css`,
+      cssChunkFilename: `static/css/chunk.[id].css`,
       publicPath: ctx.publicPath ?? imaConfig.publicPath,
       /**
        * We put hot updates into it's own folder
@@ -239,11 +243,9 @@ export default async (
       minimize: ctx.command === 'build' && !isServer,
       minimizer: [
         new TerserPlugin({
-          minify: imaConfig.experiments?.swcMinimizer
-            ? TerserPlugin.swcMinify
-            : TerserPlugin.terserMinify,
+          minify: TerserPlugin.swcMinify,
           terserOptions: {
-            ecma: isServer || isEsVersion ? 2016 : 5,
+            ecma: isServer || isEsVersion ? 2020 : 5,
             mangle: {
               // Added for profiling in devtools
               keep_classnames: ctx.profile || isDevEnv,
@@ -253,8 +255,8 @@ export default async (
         }),
         new CssMinimizerPlugin(),
       ],
-      moduleIds: 'named',
-      chunkIds: 'named',
+      moduleIds: 'deterministic',
+      chunkIds: 'deterministic',
       ...(!isServer && { runtimeChunk: 'single' }),
       splitChunks: {
         ...(isDevEnv && {
@@ -264,6 +266,7 @@ export default async (
               // Split only JS files
               test: /[\\/]node_modules[\\/](.*)(js|jsx|ts|tsx)$/,
               name: 'vendors',
+              enforce: true,
               chunks: 'all',
             },
           },
@@ -363,9 +366,15 @@ export default async (
                             targets,
                             mode: 'usage',
                             coreJs: '3.22.7',
+                            bugfixes: true,
                           },
                           module: {
                             type: 'commonjs',
+                          },
+                          jsc: {
+                            parser: {
+                              syntax: 'ecmascript',
+                            },
                           },
                           sourceMaps: useSourceMaps,
                           inlineSourcesContent: useSourceMaps,
@@ -389,9 +398,10 @@ export default async (
                           mode: 'usage',
                           coreJs: '3.22.7',
                           shippedProposals: true,
+                          bugfixes: true,
                         },
                         module: {
-                          type: 'commonjs',
+                          type: 'es6',
                         },
                         jsc: {
                           parser: {

--- a/packages/cli/src/webpack/utils.ts
+++ b/packages/cli/src/webpack/utils.ts
@@ -177,7 +177,6 @@ function createCacheKey(
   hash.update(
     JSON.stringify({
       experimentsSwc: imaConfig.experiments?.swc,
-      experimentsSwcMinimizer: imaConfig.experiments?.swcMinimizer,
       experimentsCss: imaConfig.experiments?.css,
       command: ctx.command,
       forceSPA: ctx.forceSPA,

--- a/packages/cli/src/webpack/utils.ts
+++ b/packages/cli/src/webpack/utils.ts
@@ -220,8 +220,7 @@ async function resolveImaConfig(args: ImaCliArgs): Promise<ImaConfig> {
     imageInlineSizeLimit: 8192,
     watchOptions: {
       ignored: ['**/.git/**', '**/node_modules/**', '**/build/**'],
-      followSymlinks: true,
-      aggregateTimeout: 80,
+      aggregateTimeout: 5,
     },
     babel: async config => config,
     swc: async config => config,


### PR DESCRIPTION
- Fixed code splitting for dynamic imports
- SWC minimizer now made default since it produces same bundle sizes as terser and is much faster
- Improved swc config to compile to es6 modules and fixed preset-env config (now it only compiles bugfixes in supported syntaxes -> this for example results in optional chaining no longer being always compiled but only few cases that dont work for targeted environments)
- **enables tree shaking**