### PR TITLE
Fix redirect

### DIFF
--- a/docs/docs/routing.md
+++ b/docs/docs/routing.md
@@ -209,15 +209,17 @@ export let init = (ns, oc, config) => {
     .use(async (params, locals) => {
       console.log('Matched current route object', locals.route);
       console.log('Global middleware', params, locals);
-    });
-    .add('home', '/', HomeController, HomeView, {}, [
-      async (params, locals) => {
-        locals.homeMiddleware = 0;
-      },
-      async (params, locals) => {
-        locals.homeMiddleware++;
-      }
-    ])
+    })
+    .add('home', '/', HomeController, HomeView, {
+      middlewares: [
+        async (params, locals) => {
+          locals.homeMiddleware = 0;
+        },
+        async (params, locals) => {
+          locals.homeMiddleware++;
+        }
+      ]
+    })
     .add(RouteNames.ERROR, '/error', ErrorController, ErrorView)
     .add(RouteNames.NOT_FOUND, '/not-found', NotFoundController, NotFoundView);
 }

--- a/docs/tutorial/fetching-the-data-from-the-server.md
+++ b/docs/tutorial/fetching-the-data-from-the-server.md
@@ -11,7 +11,7 @@ mock the data fetching from server and learn more about IMA.js object container.
 
 We won't go into building a REST API server with an actual database storing the
 guestbook posts - that is beyond this tutorial and IMA.js. To give you the idea
-of fetching data from the server, we'll create a more simple alternative.
+of fetching data from the server, we'll create a simpler alternative.
 
 We'll start by creating the `app/assets/static/api` directory and the
 `app/assets/static/api/posts.json` file with the following content (**copied from
@@ -195,7 +195,7 @@ you are working with as required.
 
 So how do we actually start using our post service? First we need to wire
 everything up, well we actually already did that. You may have noticed that in most of the 
-classed we used some weird static getter called `$dependencies`, that's how IMA.js built 
+classes we used some weird static getter called `$dependencies`, that's how IMA.js built 
 in dependency injection works.
 
 IMA.js uses internally the Object Container class to handle all dependencies (you can

--- a/docs/tutorial/final-polish.md
+++ b/docs/tutorial/final-polish.md
@@ -207,7 +207,7 @@ return {
 
 We added the `pendingPosts` field to our state, which we'll use to keep track
 of the posts that are being submitted to the server. We'll need the **post
-factory** in **our home controller controller** to create the entities representing the pending
+factory** in **our home controller** to create the entities representing the pending
 posts, so let's modify controller's the constructor by adding a new parameter
 and a field for the post factory:
 
@@ -220,7 +220,7 @@ constructor(postService, postFactory) {
 }
 ```
 
-And, of course, we need to updated the `$dependencies` list so OC can inject
+And, of course, we need to update the `$dependencies` list so OC can inject
 PostFactory instance to our constructor as a second argument. so modify the dependencies of the **home
 page controller** (`app/page/home/HomeController.js`) to the following:
 

--- a/docs/tutorial/static-view.md
+++ b/docs/tutorial/static-view.md
@@ -61,7 +61,7 @@ Now that we know our way around our component, let's replace the contents of
 the `render()` method with the following code:
 
 ```jsx
-return return <div className="l-home container">Hello {'World'}!</div>;
+return <div className="l-home container">Hello {'World'}!</div>;
 ```
 
 The "HTML" code you see is actually an XML markup with JavaScript expressions
@@ -191,7 +191,7 @@ we will just use the CDN-hosted CSS file, since we don't need any of Bootstrap's
 
 In a real application, we strongly recommend you manage these dependencies yourself (for example through npm packages),
 and consider using a custom build that includes only the necessary CSS/JS.
-*this is*
+<!-- *this is* -->
 
 First we need to include a few files to our page. Open the document component
 `app/component/document/DocumentView.jsx` (this is the UI component that renders the basic structure of the HTML document. You'll find more details about it in the [Rendering the whole document](#rendering-the-whole-document) section of this chapter).

--- a/packages/core/src/page/handler/PageNavigationHandler.js
+++ b/packages/core/src/page/handler/PageNavigationHandler.js
@@ -46,12 +46,8 @@ export default class PageNavigationHandler extends PageManagerHandler {
       options: { autoScroll },
     } = nextManagedPage;
 
-    if (
-      managedPage &&
-      action &&
-      action.type !== ActionTypes.POP_STATE &&
-      action.type !== ActionTypes.ERROR
-    ) {
+    // There was a condition checking for ERROR action type. I have removed it, because it was blocking redirects from plugin-redirect. More into in https://youtrack.seznam.net/issue/BLOGY-494
+    if (managedPage && action && action.type !== ActionTypes.POP_STATE) {
       const isRedirection = action.type === ActionTypes.REDIRECT;
 
       if (!isRedirection) {

--- a/packages/core/src/page/handler/PageNavigationHandler.js
+++ b/packages/core/src/page/handler/PageNavigationHandler.js
@@ -46,7 +46,7 @@ export default class PageNavigationHandler extends PageManagerHandler {
       options: { autoScroll },
     } = nextManagedPage;
 
-    // There was a condition checking for ERROR action type. I have removed it, because it was blocking redirects from plugin-redirect. More into in https://youtrack.seznam.net/issue/BLOGY-494
+    // There was a condition checking for ERROR action type. I have removed it, because it was blocking redirects from plugin-redirect. More info in https://youtrack.seznam.net/issue/BLOGY-494
     if (managedPage && action && action.type !== ActionTypes.POP_STATE) {
       const isRedirection = action.type === ActionTypes.REDIRECT;
 

--- a/packages/core/src/page/handler/PageNavigationHandler.js
+++ b/packages/core/src/page/handler/PageNavigationHandler.js
@@ -46,7 +46,6 @@ export default class PageNavigationHandler extends PageManagerHandler {
       options: { autoScroll },
     } = nextManagedPage;
 
-    // There was a condition checking for ERROR action type. I have removed it, because it was blocking redirects from plugin-redirect. More info in https://youtrack.seznam.net/issue/BLOGY-494
     if (managedPage && action && action.type !== ActionTypes.POP_STATE) {
       const isRedirection = action.type === ActionTypes.REDIRECT;
 

--- a/packages/core/src/router/AbstractRouter.js
+++ b/packages/core/src/router/AbstractRouter.js
@@ -374,7 +374,7 @@ export default class AbstractRouter extends Router {
     params = this._addParamsFromOriginalRoute(params);
 
     const action = {
-      url: this.getUrl(),
+      url: this.getBaseUrl() + this._getCurrentlyRoutedPath(),
       type: ActionTypes.ERROR,
     };
 

--- a/packages/core/src/router/__tests__/AbstractRouterSpec.js
+++ b/packages/core/src/router/__tests__/AbstractRouterSpec.js
@@ -37,6 +37,10 @@ describe('ima.core.router.AbstractRouter', () => {
     type: ActionTypes.ERROR,
     url: 'http://www.domain.com/root/currentRoutePath',
   };
+  let redirectAction = {
+    type: ActionTypes.ERROR,
+    url: 'http://www.domain.com/root/user/2345',
+  };
   let currentRoutePath = '/currentRoutePath';
   let Controller = function Controller() {};
   let View = function View() {};
@@ -422,7 +426,7 @@ describe('ima.core.router.AbstractRouter', () => {
               userId: '2345',
             }),
             options,
-            errorAction
+            redirectAction
           );
           expect(response.error instanceof GenericError).toBeTruthy();
           expect(router._runMiddlewares).toHaveBeenCalledWith(
@@ -434,7 +438,7 @@ describe('ima.core.router.AbstractRouter', () => {
               ...params,
               userId: '2345',
             }),
-            { route, action: errorAction }
+            { route, action: redirectAction }
           );
           done();
         })


### PR DESCRIPTION
We discovered a problem, where URL redirects kept throwing 404 error. To fix it, we need to make 2 changes in the core.
1. set the url in `action` object to where we want to be redirected, instead of where we currently are
2. remove part of condition in `PageManagerHandler` checking for error type.

I also fixed the snippet about middleware and corrected few typos.