### PR TITLE
Fix rmSync in initApp

### DIFF
--- a/utils/scripts/utils/utils.js
+++ b/utils/scripts/utils/utils.js
@@ -261,7 +261,7 @@ function initApp(destDir, pkgDirs, cliArgs) {
       packFiles.push(packFilePath);
     });
 
-    packFiles.forEach(fs.rmSync);
+    packFiles.forEach(packFilePath => fs.rmSync(packFilePath));
   }
 }
 


### PR DESCRIPTION
The index was being passed as an `options` parameter to `rmSync` causing an error of `npm run dev ... -- --init`