### PR TITLE
Fixed issue where swcTransformer didn't transform jsx filenames to js extension

### DIFF
--- a/.changeset/curvy-shoes-compete.md
+++ b/.changeset/curvy-shoes-compete.md
@@ -1,0 +1,5 @@
+---
+"@ima/plugin-cli": patch
+---
+
+Fixed issue where swcTransformer didn't transform jsx filenames to js extensions

--- a/packages/plugin-cli/src/transformers/swcTransformer.ts
+++ b/packages/plugin-cli/src/transformers/swcTransformer.ts
@@ -2,7 +2,7 @@ import { Options, transform } from '@swc/core';
 
 import { Transformer } from '../types';
 
-const EXTENSION_TRANSFORM_RE = /\.(t|j)sx?/;
+const EXTENSION_TRANSFORM_RE = /\.(t|j)sx?$/;
 
 export type SWCTransformerOptions = Options;
 

--- a/packages/plugin-cli/src/transformers/swcTransformer.ts
+++ b/packages/plugin-cli/src/transformers/swcTransformer.ts
@@ -2,15 +2,14 @@ import { Options, transform } from '@swc/core';
 
 import { Transformer } from '../types';
 
-const TSX_RE = /\.tsx?/;
+const EXTENSION_TRANSFORM_RE = /\.(t|j)sx?/;
 
 export type SWCTransformerOptions = Options;
 
 export function swcTransformer(options: SWCTransformerOptions): Transformer {
   return async ({ source }) => {
     const { code, map } = await transform(source.code, options);
-
-    const newFilename = source.fileName.replace(TSX_RE, '.js');
+    const newFilename = source.fileName.replace(EXTENSION_TRANSFORM_RE, '.js');
 
     return {
       fileName: newFilename,


### PR DESCRIPTION
Fixed issue where swcTransformer didn't transform jsx filenames to js extension