### PR TITLE
Reworked build of 3rd party dependencies

### DIFF
--- a/.changeset/popular-rice-approve.md
+++ b/.changeset/popular-rice-approve.md
@@ -1,0 +1,8 @@
+---
+"@ima/core": patch
+"create-ima-app": patch
+---
+
+Removed bundling of `shippedProposals`, this can still be enabled through ima.config.js if desired.
+Updated @ima/react-hooks dependency to latest version.
+Vendor files are not being processed through swc from now only, except filenames under `@ima` namespace and any additional paths defined in the `transformVendorPaths` ima.config.js option.

--- a/createWebpackConfig.js
+++ b/createWebpackConfig.js
@@ -61,7 +61,7 @@ function createWebpackConfig(callback) {
                   bugfixes: true,
                   modules: false,
                   useBuiltIns: 'usage',
-                  corejs: { version: '3.21', proposals: true },
+                  corejs: { version: '3.21' },
                   exclude: ['transform-typeof-symbol'],
                 },
               ],

--- a/docs/cli/compiler-features.md
+++ b/docs/cli/compiler-features.md
@@ -38,15 +38,13 @@ To bundle JS files we opted to use [swc](https://swc.rs/), a Rust-based JavaScri
 
 By default the application **compiles both**, the **application files** (sourced from `./app` folder) and **vendor files** (sourced from `./node_modules` directory) to make sure that it can run in targeted environments without any issues.
 
-The swc compiler is configured to leverage the power of "env" functionality (preset-env in babel), in combination with [core-js](https://github.com/zloirock/core-js) to **automatically polyfill missing APIs** that are used throughout the codebase, that the targeted environment doesn't support. This also includes [future ECMAscript proposals](https://github.com/zloirock/core-js#ecmascript-proposals) but in this case **only for the application bundle**.
+The swc compiler is configured to leverage the power of "env" functionality (preset-env in babel), in combination with [core-js](https://github.com/zloirock/core-js) to **automatically polyfill missing APIs** that are used throughout the codebase, that the targeted environment doesn't support.
 
 This configuration can be easily customized using [swc option in ima.config.js](./ima.config.js#swc).
 
 :::note
 
-This means that you can write your code **using the latest and greatest from the ECMAscript language**, even proposals and the swc makes sure to compile these features down to the latest supported syntax or automatically inject core-js polyfills.
-
-Any **3rd party npm package** should also be safe to use, since we run more lightweight version of swc over the vendor bundle as well.
+This means that you can write your code **using the latest and greatest from the ECMAscript language** and the swc makes sure to compile these features down to the latest supported syntax or automatically inject core-js polyfills.
 
 :::
 

--- a/docs/cli/ima.config.js.md
+++ b/docs/cli/ima.config.js.md
@@ -95,7 +95,7 @@ module.exports = {
 
 Similarly to `webpack`, this function is executed with the `swc-loader` [default options](https://github.com/seznam/ima/blob/packages/cli/src/webpack/config.ts#L401) and it's result is then passed to the loader itself. This allows you to customize the swc compiler options in easier and more direct way than you'd have to do when using the `webpack` option.
 
-For example, to disable bundling of core-js files for the ECMAScript proposals, you would do the following:
+For example, to **enable support** for the [ECMAScript proposals core-js feature](https://github.com/zloirock/core-js#stage-3-proposals), you would do the following:
 
 ```js title=./ima.config.js
 /**
@@ -103,18 +103,17 @@ For example, to disable bundling of core-js files for the ECMAScript proposals, 
  */
 module.exports = {
   swc: async (swcLoaderOptions, ctx) => {
-    swcLoaderOptions.env.shippedProposals = false;
+    swcLoaderOptions.env.shippedProposals = true;
 
     return swcLoaderOptions;
   },
 };
 ```
 
-:::note
+### swcVendor
+> `async function(swcLoaderOptions, ctx): swcLoaderOptions`
 
-To see all possible options the swc compiler supports, take a look at the [documentation](https://swc.rs/docs/configuration/compilation).
-
-:::
+Works same as the aforementioned [`swc`](./ima.config.js.md#swc) options, except this config is applied to vendor files that match regular expressions defined in the [`transformVendorPaths`](./ima.config.js.md#transformvendorpaths) settings.
 
 ### postcss
 > `async function(postCssLoaderOptions, ctx): postCssLoaderOptions`
@@ -311,6 +310,26 @@ Set to true to disable building of the `client` bundle (older ECMAScript target)
 The application will now only execute the modern version of the client bundle (`client.es`), meaning that the it will only work on the latest versions of modern browsers.
 
 This can be usefull if you're building an app, where you are able to set constrains for the supported browsers (e.g. internal admin page).
+
+:::
+
+### transformVendorPaths
+
+> `RegExp[]`
+
+:::caution
+
+This is an advanced feature.
+
+:::
+
+Array of regular expressions that are matched agains file paths of processed vendor files *(= imported files from node_modules)*. These files are then processed through [`swc-loader`](./ima.config.js.md#swcvendor) that makes sure to compile their syntax to currently supported target *(ES9, ES13 and node 18 currently)*.
+
+By default the CLI always matches all files under the `@ima` namespace, since we release our plugins in latest ECMA syntax and they need to be compiled down to older syntaxes with proper core-js polyfills.
+
+:::tip
+
+If you use any **3rd party** libraries that you are not sure if they support your currently supported browser environments, add their package names as regular expressions to this array and they will be compiled using swc-loader with proper polyfill injections from the core-js package.
 
 :::
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -109,6 +109,15 @@ export type ImaConfig = {
   ) => Promise<Record<string, unknown>>;
 
   /**
+   * Function which receives default vendor swc-loader config and current context,
+   * this can be used for additional customization of vendor processed files.
+   */
+  swcVendor: (
+    config: Record<string, unknown>,
+    ctx: ImaConfigurationContext
+  ) => Promise<Record<string, unknown>>;
+
+  /**
    * Function which receives postcss-loader config and current context, this can be used
    * to customize existing default postcss config or completely replace it with a custom one.
    */
@@ -205,6 +214,14 @@ export type ImaConfig = {
    * Disables build of 'client' legacy bundle.
    */
   disableLegacyBuild?: boolean;
+
+  /**
+   * Advanced functionality allowing you to register custom vendor paths that go through
+   * swc loader (configured using swcVendor function). Use this if you're using dependencies
+   * that don't meet the lowest supported ES version target (ES9 by default). It is enabled
+   * by default for all packages in @ima namespace.
+   */
+  transformVendorPaths?: RegExp[];
 
   /**
    * Experimental configurations which can be enabled individually on specific applications.

--- a/packages/cli/src/webpack/config.ts
+++ b/packages/cli/src/webpack/config.ts
@@ -438,7 +438,7 @@ export default async (
                     transform: {
                       react: {
                         runtime: imaConfig.jsxRuntime ?? 'automatic',
-                        development: false,
+                        development: isDevEnv,
                         refresh: useHMR,
                         useBuiltins: true,
                       },

--- a/packages/cli/src/webpack/config.ts
+++ b/packages/cli/src/webpack/config.ts
@@ -381,7 +381,7 @@ export default async (
               test: /\.(js|mjs|cjs)$/,
               include: [/\b@ima\b/, ...(imaConfig.transformVendorPaths ?? [])],
               use: [
-                {
+                !isServer && {
                   loader: require.resolve('swc-loader'),
                   options: await imaConfig.swcVendor(
                     {

--- a/packages/cli/src/webpack/config.ts
+++ b/packages/cli/src/webpack/config.ts
@@ -157,6 +157,7 @@ export default async (
         loader: require.resolve('less-loader'),
         options: {
           sourceMap: useSourceMaps,
+          implementation: require('less'),
         },
       },
       useLessLoader && {
@@ -378,31 +379,35 @@ export default async (
              */
             {
               test: /\.(js|mjs|cjs)$/,
-              exclude: [/\bcore-js\b/, /\bwebpack\/buildin\b/, appDir],
+              include: [/\b@ima\b/, ...(imaConfig.transformVendorPaths ?? [])],
               use: [
-                !isServer && {
+                {
                   loader: require.resolve('swc-loader'),
-                  options: {
-                    env: {
-                      targets,
-                      mode: 'usage',
-                      coreJs: coreJsVersion,
-                      bugfixes: true,
-                      dynamicImport: true,
-                    },
-                    module: {
-                      type: 'commonjs',
-                    },
-                    jsc: {
-                      parser: {
-                        syntax: 'ecmascript',
+                  options: await imaConfig.swcVendor(
+                    {
+                      env: {
+                        targets,
+                        mode: 'usage',
+                        coreJs: coreJsVersion,
+                        bugfixes: true,
+                        dynamicImport: true,
                       },
+                      module: {
+                        type: 'es6',
+                      },
+                      jsc: {
+                        parser: {
+                          syntax: 'ecmascript',
+                        },
+                      },
+                      sourceMaps: useSourceMaps,
+                      inlineSourcesContent: useSourceMaps,
                     },
-                    sourceMaps: useSourceMaps,
-                    inlineSourcesContent: useSourceMaps,
-                  },
+                    ctx
+                  ),
                 },
                 {
+                  // TODO IMA@18 remove before release
                   // This injects new plugin loader interface into legacy plugins
                   loader: 'ima-legacy-plugin-loader',
                 },
@@ -419,7 +424,6 @@ export default async (
                     targets,
                     mode: 'usage',
                     coreJs: coreJsVersion,
-                    shippedProposals: true,
                     bugfixes: true,
                     dynamicImport: true,
                   },
@@ -434,7 +438,7 @@ export default async (
                     transform: {
                       react: {
                         runtime: imaConfig.jsxRuntime ?? 'automatic',
-                        development: isDevEnv,
+                        development: false,
                         refresh: useHMR,
                         useBuiltins: true,
                       },

--- a/packages/cli/src/webpack/utils.ts
+++ b/packages/cli/src/webpack/utils.ts
@@ -222,6 +222,7 @@ async function resolveImaConfig(args: ImaCliArgs): Promise<ImaConfig> {
       aggregateTimeout: 5,
     },
     swc: async config => config,
+    swcVendor: async config => config,
     postcss: async config => config,
   };
 

--- a/packages/create-ima-app/template/package.json
+++ b/packages/create-ima-app/template/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@ima/core": "18.0.0-rc.10",
-    "@ima/react-hooks": "2.0.0-rc.2",
+    "@ima/react-hooks": "2.0.0-rc.3",
     "@ima/server": "18.0.0-rc.8",
     "body-parser": "^1.19.2",
     "compression": "1.7.4",


### PR DESCRIPTION
- 3rd party dependencies are no longer processed through swc (except anything under `@ima` namespace).
- this can be extended using custom path regexps in the newly added `transformVendorPaths` ima.config.js option.
- additionaly I have disabled inclusion of `shippedProposals`, since this option can be easily enabled on per-project basis and it adds addition 18kB in minified bundle, while it will probably never be used.