### PR TITLE
Changed re-bind behaviour - not change dependencies for classConstruc…

### DIFF
--- a/.changeset/smart-timers-grow.md
+++ b/.changeset/smart-timers-grow.md
@@ -1,0 +1,5 @@
+---
+"@ima/core": major
+---
+
+Changed re-bind behaviour - not change dependencies for classConstructorEntry

--- a/packages/core/src/ObjectContainer.ts
+++ b/packages/core/src/ObjectContainer.ts
@@ -191,7 +191,7 @@ export default class ObjectContainer {
 
     const classConstructorEntry = this._entries.get(classConstructor);
     const nameEntry = this._entries.get(name);
-    const entry = classConstructorEntry || nameEntry;
+    const entry = nameEntry || classConstructorEntry;
 
     if (classConstructorEntry && !nameEntry && dependencies) {
       const entry = this._createEntry(classConstructor, dependencies);


### PR DESCRIPTION
BREAKING CHANGE: Changed re-bind behaviour - not change dependencies for classConstructorEntry

Use-case

oc.inject(ClassX, [depA]); //for  oc.get(ClassX)  gets dependency A 
oc.bind('A', ClassX, [depB]); //for oc.get('a') gets new instance of ClassX with dependency B
    //if change dependency for A - it changed dependency also for ClassX
oc.bind('A', ClassX, [depX]);  //for  oc.get(ClassX) gets dependency X 