### PR TITLE
Fix dev empty language

### DIFF
--- a/.changeset/blue-poets-fold.md
+++ b/.changeset/blue-poets-fold.md
@@ -1,0 +1,5 @@
+---
+"@ima/server": patch
+---
+
+Fix not set \$Language for dev environment

--- a/packages/server/lib/factory/environmentFactory.js
+++ b/packages/server/lib/factory/environmentFactory.js
@@ -20,13 +20,19 @@ module.exports = function environmentFactory({ applicationFolder }) {
   ));
 
   let currentEnvironment = environmentConfig[env];
-  let $Language = Object.assign({}, currentEnvironment.$Language);
+  let $Language =
+    currentEnvironment.$Language &&
+    Object.assign({}, currentEnvironment.$Language);
 
   currentEnvironment = helpers.resolveEnvironmentSetting(
     environmentConfig,
     env
   );
-  currentEnvironment.$Language = $Language;
+
+  if ($Language) {
+    currentEnvironment.$Language = $Language;
+  }
+
   currentEnvironment['$Env'] = env;
 
   return currentEnvironment;


### PR DESCRIPTION
Fix not set $Language in dev environment.
For $Languages we do not want to merge production and dev settings. I think thats why in environmentFactory $Languages is preserving its value. But if $Languages is not set in dev it does not make sense. 