### PR TITLE
fix: add exports definition with backwards compatibility

### DIFF
--- a/.changeset/happy-hounds-kiss.md
+++ b/.changeset/happy-hounds-kiss.md
@@ -1,0 +1,6 @@
+---
+"@ima/react-page-renderer": patch
+"create-ima-app": patch
+---
+
+Added possibility to import from dist folder without specifying the bundle (cjs/esm/client/server). For example, you can change `import Renderer from '@ima/react-page-renderer/dist/esm/client/renderer/ClientPageRenderer'` to `import Renderer from '@ima/react-page-renderer/renderer/ClientPageRenderer'`.

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -2,7 +2,6 @@ const defaultConfig = require('../../jest.config.base.js');
 
 module.exports = {
   ...defaultConfig,
-  testEnvironment: 'jsdom',
   testRegex: '(/__tests__/).*Spec\\.[jt]s$',
   transform: {
     '\\.[jt]s?$': ['ts-jest'],

--- a/packages/core/src/__tests__/reviveClientAppSpec.ts
+++ b/packages/core/src/__tests__/reviveClientAppSpec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import React from 'react';
 import {
   AbstractPureComponent,

--- a/packages/core/src/http/__tests__/HttpProxySpec.ts
+++ b/packages/core/src/http/__tests__/HttpProxySpec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable jest/no-conditional-expect */
 import HttpProxy from '../HttpProxy';

--- a/packages/core/src/page/handler/__tests__/PageNavigationHandlerSpec.ts
+++ b/packages/core/src/page/handler/__tests__/PageNavigationHandlerSpec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
 import PageNavigationHandler from '../PageNavigationHandler';

--- a/packages/core/src/page/manager/__tests__/ClientPageManagerSpec.ts
+++ b/packages/core/src/page/manager/__tests__/ClientPageManagerSpec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable jest/no-conditional-expect */

--- a/packages/core/src/router/__tests__/ClientRouterSpec.ts
+++ b/packages/core/src/router/__tests__/ClientRouterSpec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import Dispatcher from '../../event/Dispatcher';
 import PageManager from '../../page/manager/PageManager';
 import ActionTypes from '../ActionTypes';

--- a/packages/create-ima-app/template/app/config/bind.js
+++ b/packages/create-ima-app/template/app/config/bind.js
@@ -4,7 +4,7 @@ import {
   PageRendererFactory,
   ServerPageRenderer,
 } from '@ima/react-page-renderer';
-import ClientPageRenderer from '@ima/react-page-renderer/dist/esm/client/renderer/ClientPageRenderer';
+import ClientPageRenderer from '@ima/react-page-renderer/renderer/ClientPageRenderer';
 
 //eslint-disable-next-line no-unused-vars
 export default (ns, oc, config) => {

--- a/packages/create-ima-app/template/server/app.js
+++ b/packages/create-ima-app/template/server/app.js
@@ -5,7 +5,7 @@ const imaServer = require('@ima/server')();
 const { serverApp, urlParser, environment, logger, cache, memStaticProxy } =
   imaServer;
 
-require('@ima/react-page-renderer/dist/hook/server')(imaServer);
+require('@ima/react-page-renderer/hook/server')(imaServer);
 
 const express = require('express');
 const favicon = require('serve-favicon');

--- a/packages/react-page-renderer/package.json
+++ b/packages/react-page-renderer/package.json
@@ -17,9 +17,24 @@
   "license": "MIT",
   "author": "Matěj Marčišovský <matej.marcisovsky@firma.seznam.cz>",
   "typedocMain": "./src/index.ts",
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/server/index.js",
-  "browser": "./dist/esm/client/index.js",
+  "exports": {
+    ".": {
+      "node": {
+        "import": "./dist/esm/server/index.js",
+        "require": "./dist/cjs/index.js"
+      },
+      "default": "./dist/esm/client/index.js"
+    },
+    "./renderer/*": {
+      "node": {
+        "import": "./dist/esm/server/renderer/*.js",
+        "require": "./dist/cjs/renderer/*.js"
+      },
+      "default": "./dist/esm/client/renderer/*.js"
+    },
+    "./hook/*": "./dist/hook/*.js",
+    "./*": "./*.js"
+  },
   "types": "./dist/esm/client/index.js",
   "scripts": {
     "dev": "node ../plugin-cli/dist/bin/ima-plugin.js dev",


### PR DESCRIPTION
Explanation:

```
 "exports": {
    // Import of index file
    // import { ServerPageRenderer } from '@ima/react-page-renderer'
    ".": {
      "node": {
        "import": "./dist/esm/server/index.js",
        "require": "./dist/cjs/index.js"
      },
      "default": "./dist/esm/client/index.js"
    },
    // Shortcut for renderers
    "./renderer/*": {
      "node": {
        "import": "./dist/esm/server/renderer/*.js",
        "require": "./dist/cjs/renderer/*.js"
      },
      "default": "./dist/esm/client/renderer/*.js"
    },
    // Shortcut for hooks
    "./hook/*": "./dist/hook/*.js",
    // Backwards compatibility
    "./*": "./*.js"
  },
  ```

With IMA 19 we can drop backwards compatibility and change exports to something like this.

```
 "exports": {
    // Import of index file
    ".": {
      "node": {
        "import": "./dist/esm/server/index.js",
        "require": "./dist/cjs/index.js"
      },
      "default": "./dist/esm/client/index.js"
    },
    // This hook folder is quite atypical, its transpiled outside of src folder and not categorized under cjs/esm folder
    "./hook/*": "./dist/hook/*.js",
    // Direct file imports
    "./*": {
      "node": {
        "import": "./dist/esm/server/*.js",
        "require": "./dist/cjs/*.js"
      },
      "default": "./dist/esm/client/*.js"
    },
  },
```