### PR TITLE
fix: css files generated in manifest are from static/css folder

### DIFF
--- a/.changeset/large-seas-watch.md
+++ b/.changeset/large-seas-watch.md
@@ -1,0 +1,5 @@
+---
+"@ima/cli": patch
+---
+
+CSS files generated to Manifest are only from static/css/ folder.

--- a/packages/cli/src/webpack/plugins/ManifestPlugin/index.ts
+++ b/packages/cli/src/webpack/plugins/ManifestPlugin/index.ts
@@ -148,7 +148,7 @@ class ManifestPlugin {
 
     // Include CSS only from the root directory
     if (this.#options.context.processCss) {
-      result = result || /css\/[\w.\-_]+\.css$/.test(assetName);
+      result = result || /static\/css\/[\w.\-_]+\.css$/.test(assetName);
     }
 
     return result;


### PR DESCRIPTION
Ignore css files from /app/public/css/*.css to be generated in manifest.json.