### PR TITLE
ObjectContainer throw error for undefined dependency

### DIFF
--- a/.changeset/honest-pianos-hope.md
+++ b/.changeset/honest-pianos-hope.md
@@ -1,0 +1,5 @@
+---
+"@ima/core": patch
+---
+
+The ObjectContainer throw new error if dependency of dependencies for class constructor is undefined.

--- a/packages/core/src/cache/CacheImpl.ts
+++ b/packages/core/src/cache/CacheImpl.ts
@@ -37,7 +37,7 @@ export class CacheImpl<V> extends Cache<V> {
     cacheStorage: Storage<CacheEntry<V>>,
     factory: CacheFactory<V>,
     Helper: typeof Helpers,
-    config: { ttl: number; enabled: boolean } = { ttl: 30000, enabled: false }
+    { ttl = 30000, enabled = false }
   ) {
     super();
 
@@ -52,12 +52,12 @@ export class CacheImpl<V> extends Cache<V> {
     /**
      * Default cache entry time to live in milliseconds.
      */
-    this._ttl = config.ttl;
+    this._ttl = ttl;
 
     /**
      * Flag signalling whether the cache is currently enabled.
      */
-    this._enabled = config.enabled;
+    this._enabled = enabled;
   }
 
   /**

--- a/packages/core/src/config/bind.ts
+++ b/packages/core/src/config/bind.ts
@@ -178,7 +178,7 @@ export const initBind: InitBindFunction = (ns, oc, config) => {
     '$CacheStorage',
     CacheFactory,
     '$Helper',
-    config.$Cache,
+    config.$Cache || {},
   ]);
   oc.bind('$Cache', Cache);
 

--- a/packages/core/src/oc/ObjectContainer.ts
+++ b/packages/core/src/oc/ObjectContainer.ts
@@ -690,6 +690,20 @@ export class ObjectContainer {
       dependencies = [];
 
       for (const dependency of entry.dependencies) {
+        if ($Debug && dependency === undefined) {
+          throw new GenericError(
+            `ima.core.ObjectContainer:_createInstanceFromEntry The dependency ` +
+              `of class constructor function ${this.#getDebugName(
+                entry.classConstructor
+              )} is undefined. Fix class constructor $dependencies.`,
+            {
+              classConstructor: entry.classConstructor,
+              referrer: entry.referrer,
+              dependencies: entry.dependencies?.toString(),
+            }
+          );
+        }
+
         // Optional and spread dependency handling
         if (
           ['function', 'string'].indexOf(typeof dependency) !== -1 ||

--- a/packages/core/src/oc/__tests__/ObjectContainerSpec.ts
+++ b/packages/core/src/oc/__tests__/ObjectContainerSpec.ts
@@ -351,6 +351,18 @@ describe('ima.core.ObjectContainer', () => {
       } as Entry;
     });
 
+    it('should throw error if dependency in $dependencies is undefined', () => {
+      class A {
+        static get $dependencies() {
+          return [undefined];
+        }
+      }
+
+      expect(() => {
+        oc.get(A);
+      }).toThrow();
+    });
+
     it('should return shared instance', () => {
       entry.sharedInstance = false;
 


### PR DESCRIPTION
The ObjectContainer throw new error if dependency of dependencies for class constructor is undefined.