### PR TITLE
Removed ClientRouter.getUrl implementation

### DIFF
--- a/packages/core/src/router/ClientRouter.ts
+++ b/packages/core/src/router/ClientRouter.ts
@@ -109,13 +109,6 @@ export class ClientRouter extends AbstractRouter {
   /**
    * @inheritDoc
    */
-  getUrl() {
-    return this._window.getUrl();
-  }
-
-  /**
-   * @inheritDoc
-   */
   getPath() {
     return this._extractRoutePath(this._window.getPath());
   }

--- a/packages/core/src/router/__tests__/ClientRouterSpec.ts
+++ b/packages/core/src/router/__tests__/ClientRouterSpec.ts
@@ -35,7 +35,7 @@ describe('ima.core.router.ClientRouter', () => {
       30000
     );
 
-    jest.spyOn(router, 'getPath').mockReturnValue('/routePath');
+    jest.spyOn(router, 'getPath').mockReturnValue('/routePath?foo=bar');
 
     router.init(routerConfig);
   });
@@ -50,11 +50,13 @@ describe('ima.core.router.ClientRouter', () => {
   });
 
   it('should be return actual url', () => {
-    jest.spyOn(window, 'getUrl').mockImplementation();
+    jest.spyOn(router, 'getBaseUrl');
+    jest.spyOn(router, 'getPath');
 
-    router.getUrl();
+    expect(router.getUrl()).toBe('http://locahlost:3002/routePath?foo=bar');
 
-    expect(window.getUrl).toHaveBeenCalled();
+    expect(router.getBaseUrl).toHaveBeenCalled();
+    expect(router.getPath).toHaveBeenCalled();
   });
 
   it('should add listener to popState event, click event', () => {


### PR DESCRIPTION
`ClientRouter.getUrl()` acts as a proxy to `window.location.href`, which returns the URL including hash parameters. However, this behavior is not consistent with the server implementation. To improve consistency, we can use the `AbstractRouter.getUrl()` implementation on both the client and server sides.