### PR TITLE
Adds flag `batchResolveNoTransaction` as a new `PageRendererSettings`…

### DIFF
--- a/.changeset/mighty-ligers-give.md
+++ b/.changeset/mighty-ligers-give.md
@@ -1,0 +1,6 @@
+---
+"@ima/react-page-renderer": minor
+"@ima/core": minor
+---
+
+Adds flag `batchResolveNoTransaction` as a new `PageRendererSettings`. When it is true, transaction is not used in load phase to avoid getting obsolete state from getState.

--- a/packages/core/src/boot.ts
+++ b/packages/core/src/boot.ts
@@ -121,6 +121,7 @@ export interface AppEnvironment {
 
 export interface PageRendererSettings {
   batchResolve?: boolean;
+  batchResolveNoTransaction?: boolean;
   masterElementId: string;
   documentView: unknown;
   managedRootView?: unknown;


### PR DESCRIPTION
…. When it is true, transaction is not used in load phase to avoid getting obsolete state from getState.