### PR TITLE
fix: remove broken sourcemaps, fix esm build, remove extensionless hacks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20153,12 +20153,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/extensionless": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/extensionless/-/extensionless-2.0.6.tgz",
-      "integrity": "sha512-Kri4UehTAnQzYpM2gySya2nsCBEChxstgtKtOqR1nqZpF0HYM+BZXaeua9uUhE4Z0CE4kfZp+0JFhKL3SsuKFA==",
-      "license": "MIT"
-    },
     "node_modules/extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -43334,7 +43328,6 @@
         "cli-progress": "^3.12.0",
         "core-js-pure": "^3.48.0",
         "express-static-gzip": "^3.0.0",
-        "extensionless": "^2.0.6",
         "globby": "11.1.0",
         "kill-port": "^1.6.1",
         "less": "^4.4.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,6 @@
     "cli-progress": "^3.12.0",
     "core-js-pure": "^3.48.0",
     "express-static-gzip": "^3.0.0",
-    "extensionless": "^2.0.6",
     "globby": "11.1.0",
     "kill-port": "^1.6.1",
     "less": "^4.4.2",

--- a/packages/cli/src/dev-server/devServer.ts
+++ b/packages/cli/src/dev-server/devServer.ts
@@ -20,7 +20,6 @@ import {
   resolveImaConfig,
   runImaPluginsHook,
 } from '../vite/utils/utils';
-import 'extensionless/register'; // @TODO: tmp hotfix of invalid esm builds
 
 const args: ImaCliArgs = JSON.parse(process.env.IMA_CLI_ARGS!);
 

--- a/packages/cli/src/vite/config.ts
+++ b/packages/cli/src/vite/config.ts
@@ -209,11 +209,6 @@ export default async (
       },
       server: {
         consumer: 'server',
-        resolve: {
-          // @TODO: IMA.js packages do not have valid ESM build, this is a workaround to build them
-          noExternal: [/^@ima\//], // Bundle all @ima/* packages
-          external: true,
-        },
         build: {
           ssr: true,
           target: 'node18',

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -19,6 +19,14 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./types.d.ts",
+  "exports": {
+    ".": {
+      "types": "./types.d.ts",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/cjs/index.js"
+    }
+  },
   "scripts": {
     "test": "jest",
     "lint": "eslint './**/*.{js,jsx,ts,tsx,mjs}'",

--- a/packages/plugin-cli/src/transformers/swcTransformer.ts
+++ b/packages/plugin-cli/src/transformers/swcTransformer.ts
@@ -22,20 +22,18 @@ export function createSwcTransformer({
   syntax,
   development,
   jsxRuntime,
-  sourceMaps,
 }: {
   type: ModuleConfig['type'];
   target: JscTarget;
   syntax?: ParserConfig['syntax'];
   development?: boolean;
   jsxRuntime: ReactConfig['runtime'];
-  sourceMaps?: boolean;
 }) {
   return swcTransformer({
     isModule: true,
-    sourceMaps: sourceMaps ?? true,
     module: {
       type: type ?? 'es6',
+      resolveFully: true,
     },
     jsc: {
       target,
@@ -59,17 +57,18 @@ export function createSwcTransformer({
 export function swcTransformer(options: SWCTransformerOptions): Transformer {
   return async ({ source, context }) => {
     const newFilename = context.fileName.replace(EXTENSION_TRANSFORM_RE, '.js');
-    const { code, map } = await transform(source.code, {
+    const { code } = await transform(source.code, {
       ...options,
-      filename: newFilename,
-      sourceFileName: newFilename,
-      inputSourceMap: source.map,
+      filename: context.filePath,
+      jsc: {
+        ...options.jsc,
+        baseUrl: context.inputDir, // We need to get the path from context
+      },
     });
 
     return {
       fileName: newFilename,
-      code: map ? code + `\n//# sourceMappingURL=${newFilename}.map` : code,
-      map,
+      code,
     };
   };
 }

--- a/packages/plugin-cli/src/types.ts
+++ b/packages/plugin-cli/src/types.ts
@@ -62,7 +62,6 @@ export interface ImaPluginConfig {
   plugins?: Plugin[];
   jsxRuntime?: ReactConfig['runtime'];
   transformers?: TransformerDefinition[] | '...';
-  sourceMaps?: boolean;
   additionalWatchPaths?: string[];
 }
 

--- a/packages/plugin-cli/src/utils/process.ts
+++ b/packages/plugin-cli/src/utils/process.ts
@@ -181,7 +181,6 @@ export async function createProcessingPipeline(ctx: Context) {
       [
         createSwcTransformer({
           target: config.target,
-          sourceMaps: config.sourceMaps,
           development: isDevelopment,
           type: output.format,
           jsxRuntime: config.jsxRuntime,
@@ -191,7 +190,6 @@ export async function createProcessingPipeline(ctx: Context) {
       [
         createSwcTransformer({
           target: config.target,
-          sourceMaps: config.sourceMaps,
           development: isDevelopment,
           type: output.format,
           jsxRuntime: config.jsxRuntime,


### PR DESCRIPTION
- [x] Fix ESM builds of our plugins (and also core ima packages) to be valid ESM.
  - [x] Remove `extensionless` package. It is a workaround to hotfix the issue below.
  - [x] Fix issue with imports missing extensions
  - [x] Remove `ssr.noExternal: [/@ima/.*/]` Vite configuration. It is a workaround to bundle the @ima packages and make them work despite the issue below.
  - [x] Fix `package.json` configuration as it is probably incorrect since it shows, that only default import is exposed, not named ones.
    - It is the same bug, that we ran into with `static-content` component and added workarounds. Now it is everywhere as Vite is using ESM on server-side.
- [x] Fix sourcemaps generated by @ima/plugin-cli to point to the correct lines.
  - Webpack was ignoring sourcemaps (as it was referencing to the bundled code, not "source" code in `node_modules`, but vite references does)
  - The issue is visible in integration tests, where line references in stack traces are also incorrect (in the original IMA with Webpack)
- [x] Review, that server error stack traces are no longer off by few lines after sourcemaps are fixed for `@ima/plugin-cli`

---

Do sourcemaps make sense the way they are handled right now in `@ima/plugin-cli`?

- We point to the dist file even though the lines are refering to source file (fixable, should we add the source files to published bundle? If I want to hotfix some stuff in node_modules, it will be confusing, because I need to find what is the corresponding line in the dist)
- Preprocess plugin may break some sourcemaps if we use the specific syntax - https://github.com/jsoverson/preprocess/issues/59
- I feel like `ima-plugin link` is the only use-case, where we should use sourcemaps and point to the location from where is the user actually linking the files.

**Consulted with Slavek and we decided to turn off sourcemaps for `@ima/plugin-cli` as it does not make sense to keep them due to reasons above.**
